### PR TITLE
ci: Remove unused docker-ci target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM golang:alpine
-
-RUN apk update && apk add gcc g++ bash make git
-COPY go.mod go.sum /deps/
-RUN cd /deps && go mod download
-COPY . /gopatch
-WORKDIR /gopatch 
-ENTRYPOINT make ci

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,3 @@ $(GOLINT): tools/go.mod
 
 $(STATICCHECK): tools/go.mod
 	cd tools && go install honnef.co/go/tools/cmd/staticcheck
-
-.PHONY: docker-ci
-docker-ci:
-	docker run "$$(docker build -q .)"


### PR DESCRIPTION
This was used with the internal CI system, but with GitHub Workflows, we
don't need it.
