### PR TITLE
Add version support info to install step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ transformations, it can be smarter because it understands Go syntax.
 Install gopatch with the following command.
 
 ```bash
-go get github.com/uber-go/gopatch@latest
+go install github.com/uber-go/gopatch@latest
 ```
+Note: If you're using Go < 1.16, use `go get github.com/uber-go/gopatch@latest` instead.
 
 ## Your first patch
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ transformations, it can be smarter because it understands Go syntax.
 Install gopatch with the following command.
 
 ```bash
-go install github.com/uber-go/gopatch@latest
+go get github.com/uber-go/gopatch@latest
 ```
 
 ## Your first patch


### PR DESCRIPTION
I got an error with the steps in the readme:
```
$ go install github.com/uber-go/gopatch@latest
can't load package: package github.com/uber-go/gopatch@latest: can only use path@version syntax with 'go get'
```

Success after this fix:
```
$ go get github.com/uber-go/gopatch@latest
go: downloading github.com/uber-go/gopatch v0.0.2
go: github.com/uber-go/gopatch latest => v0.0.2
go: downloading github.com/google/go-intervals v0.0.0-20171120085516-250c62ad245e
```

Edit: it's worth noting my go version:
```
go version go1.14.4 darwin/amd64
```
And that support for version suffixes on the `install` command was [added in 1.16](https://golang.org/doc/go1.16#go-command)
So on some level, I guess this is a discussion about what versions of `go` the project supports!