### PR TITLE
import/metavar: Recognize empty imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- No changes yet.
+### Fixed
+- ([#2]): Patches with named imports now support matching and manipulating any
+  import.
+
+  [#2]: https://github.com/uber-go/gopatch/issues/2
 
 ## 0.0.2 - 2020-11-04
 ### Fixed

--- a/docs/PatchesInDepth.md
+++ b/docs/PatchesInDepth.md
@@ -414,13 +414,6 @@ can now update consumers of `foo.FooClient`.
 
 ```diff
 @@
-@@
- import "example.com/foo"
-
--foo.FooClient
-+foo.Client
-
-@@
 var foo identifier
 @@
  import foo "example.com/foo"
@@ -428,14 +421,6 @@ var foo identifier
 -foo.FooClient
 +foo.Client
 ```
-
-The first diff in this patch affects files that use unnamed imports, and the
-second affects those that use named imports---regardless of name.
-
-> *Note*: In a future version of gopatch, we'll need only the second patch to
-> make this transformation. See also, [#2].
-
-  [#2]: https://github.com/uber-go/gopatch/issues/2
 
 #### Changing imports
 
@@ -519,42 +504,16 @@ The above will match, both, named and unnamed imports of
 |---------------------------------------|-------------------------------------|
 | `import foo "example.com/foo-go.git"` | `import foo "example.com/foo.git"`  |
 | `import bar "example.com/foo-go.git"` | `import bar "example.com/foo.git"`  |
-| `import "example.com/foo-go.git"`     | `import foo "example.com/foo.git"`* |
-
-> *This case is a known bug. See [#2] for more information.
->
-> You can work around this by first explicitly matching and replacing the
-> cases with unnamed imports first. For example, turn the patch above into two
-> diffs, one addressing the unnamed imports, and one addressing the named.
->
-> ```diff
-> @@
-> var x identifier
-> @@
-> -import "example.com/foo-go.git"
-> +import "example.com/foo.git"
->
->  foo.x
->
-> @@
-> var foo, x identifier
-> @@
-> -import foo "example.com/foo-go.git"
-> +import foo "example.com/foo.git"
->
->  foo.x
-> ```
+| `import "example.com/foo-go.git"`     | `import "example.com/foo.git"`      |
 
 #### Best practices for imports
 
-Given the known limitations and issues with imports highlighted above, the
-best practices for matching and manipulating imports are:
+Given the limitations of AST analysis, gopatch cannot always accurately guess a
+package name for an import.
 
-- Handle unnamed imports first. This will make sure that previously named
-  imports do not unintentionally become named.
-- When matching any import, use a metavariable name that matches the name of
-  the imported package **exactly**. This name is used by gopatch to guess the
-  name of the package.
+As a best practice, when manipulating imports, use a metavariable name that
+matches the name of the imported package **exactly**. gopatch will use that as
+the name of the package during source analysis.
 
     ```
     # BAD                           | # GOOD

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -142,8 +142,6 @@ var testsToSkip = map[string]struct{}{
 	"add_error_param/a":              {}, // https://github.com/uber-go/gopatch/issues/6
 	"func_within_a_func/two_dots":    {},
 	"mismatched_dots/unnamed":        {}, // https://github.com/uber-go/gopatch/issues/9
-	"noop_import/remove_all":         {},
-	"noop_import/remove_some":        {},
 	"switch_elision/body":            {},
 	"select_elision/example":         {},
 	"case_elision/a":                 {},

--- a/examples/gomock-v1.5.0.patch
+++ b/examples/gomock-v1.5.0.patch
@@ -2,10 +2,10 @@
 # the test finishes running. We no longer need to call mockCtrl.Finish
 # manually.
 @@
-var ctrl identifier
+var ctrl, gomock identifier
 var t expression
 @@
- import "github.com/golang/mock/gomock"
+ import gomock "github.com/golang/mock/gomock"
 
  ctrl := gomock.NewController(t)
  ...

--- a/internal/engine/file_test.go
+++ b/internal/engine/file_test.go
@@ -553,7 +553,7 @@ func TestFile(t *testing.T) {
 			},
 		},
 		{
-			desc: "remove import",
+			desc: "remove unnamed import",
 			// -import "foo"
 			//  bar
 			minus: &pgo.File{
@@ -573,18 +573,6 @@ func TestFile(t *testing.T) {
 					giveSrc: text.Unlines(
 						"package x",
 						`import "foo"`,
-						"func bar() { bar() }",
-					),
-					wantSrc: text.Unlines(
-						"package x",
-						"func bar() { bar() }",
-					),
-				},
-				{
-					desc: "named import",
-					giveSrc: text.Unlines(
-						"package x",
-						`import baz "foo"`,
 						"func bar() { bar() }",
 					),
 					wantSrc: text.Unlines(

--- a/testdata/delete_any_import
+++ b/testdata/delete_any_import
@@ -1,9 +1,8 @@
-Delete an unnamed import verbatim.
-
 -- in.patch --
 @@
+var foo identifier
 @@
--import "foo"
+-import foo "foo"
 
   bar
 
@@ -26,7 +25,7 @@ func x() {
 -- named.in.go --
 package x
 
-import foo "foo"
+import baz "foo"
 
 func x() {
 	bar()
@@ -34,8 +33,6 @@ func x() {
 
 -- named.out.go --
 package x
-
-import foo "foo"
 
 func x() {
 	bar()

--- a/testdata/delete_field
+++ b/testdata/delete_field
@@ -53,7 +53,7 @@ func bar() {
 -- unnamed.out.go --
 package a
 
-import foo "example.com/foo.git"
+import "example.com/foo.git"
 
 func bar() {
 	foo.Initialize(foo.Params{

--- a/testdata/destutter
+++ b/testdata/destutter
@@ -1,8 +1,5 @@
 Removes stuttering in the name of a type.
 
-TODO: `var foo identifier` for named imports should not add a name when there
-wasn't there one before. fix_consumers* should be merged into one patch.
-
 -- fix.patch --
 => examples/destutter.patch
 

--- a/testdata/gomock
+++ b/testdata/gomock
@@ -64,3 +64,34 @@ func TestBar(t *testing.T) {
 
 	run(NewBarMock(ctrl))
 }
+
+-- named_import.in.go --
+package baz
+
+import (
+	"testing"
+
+	mock "github.com/golang/mock/gomock"
+)
+
+func TestBaz(t *testing.T) {
+	mockCtrl := mock.NewController(t)
+	defer mockCtrl.Finish()
+
+	run(NewBazMock(mockCtrl))
+}
+
+-- named_import.out.go --
+package baz
+
+import (
+	"testing"
+
+	mock "github.com/golang/mock/gomock"
+)
+
+func TestBaz(t *testing.T) {
+	mockCtrl := mock.NewController(t)
+
+	run(NewBazMock(mockCtrl))
+}

--- a/testdata/match_named_import
+++ b/testdata/match_named_import
@@ -1,0 +1,50 @@
+Match a named import verbatim.
+
+-- in.patch --
+@@
+var X identifier
+@@
+-import foo "example.com/bar"
++import bar "example.com/bar"
+
+-foo.X
++bar.X
+
+-- unnamed.in.go --
+package whatever
+
+import "example.com/bar"
+
+// Should remain untouched.
+func stuff() {
+	foo.stuff()
+}
+
+-- unnamed.out.go --
+package whatever
+
+import "example.com/bar"
+
+// Should remain untouched.
+func stuff() {
+	foo.stuff()
+}
+
+
+-- named.in.go --
+package whatever
+
+import foo "example.com/bar"
+
+func stuff() {
+	foo.stuff()
+}
+
+-- named.out.go --
+package whatever
+
+import bar "example.com/bar"
+
+func stuff() {
+	bar.stuff()
+}

--- a/testdata/noop_import
+++ b/testdata/noop_import
@@ -73,6 +73,7 @@ package main
 
 import (
 	"conversion/to.git"
+
 	"go.uber.org/thriftrw/ptr"
 )
 

--- a/testdata/recognize_all_imports
+++ b/testdata/recognize_all_imports
@@ -1,0 +1,44 @@
+-- in.patch --
+@@
+var foo, x identifier
+@@
+-import foo "example.com/foo-go.git"
++import foo "example.com/foo.git"
+
+ foo.x
+
+-- unnamed.in.go --
+package whatever
+
+import "example.com/foo-go.git"
+
+func foo() {
+	foo.X()
+}
+
+-- unnamed.out.go --
+package whatever
+
+import "example.com/foo.git"
+
+func foo() {
+	foo.X()
+}
+
+-- named.in.go --
+package whatever
+
+import bar "example.com/foo-go.git"
+
+func foo() {
+	bar.X()
+}
+
+-- named.out.go --
+package whatever
+
+import bar "example.com/foo.git"
+
+func foo() {
+	bar.X()
+}

--- a/testdata/replace_any_import_with_unnamed
+++ b/testdata/replace_any_import_with_unnamed
@@ -8,7 +8,7 @@ var fooclient identifier
 -fooclient.Init()
 +compat.Init()
 
--- from_unnamed.in.go --
+-- unnamed.in.go --
 package main
 
 import "example.com/foo/client"
@@ -17,7 +17,25 @@ func main() {
 	fooclient.Init()
 }
 
--- from_unnamed.out.go --
+-- unnamed.out.go --
+package main
+
+import "example.com/foo-client/compat"
+
+func main() {
+	compat.Init()
+}
+
+-- named.in.go --
+package main
+
+import client "example.com/foo/client"
+
+func main() {
+	client.Init()
+}
+
+-- named.out.go --
 package main
 
 import "example.com/foo-client/compat"

--- a/testdata/replace_net_context
+++ b/testdata/replace_net_context
@@ -1,15 +1,10 @@
-# TODO(abg): This is broken because of our current "uses import" detection
-# which treats the old context import as used, as it doesn't recognize that
-# the new one is meant to replace it.
-
 -- in.patch --
 @@
+var context identifier
 @@
--import "golang.org/x/net/context"
-+import "context"
+-import context "golang.org/x/net/context"
++import context "context"
 
-# TODO: Delete the requirement of having at least one AST-level
-# match/replacement.
  context
 
 -- top_level.in.go --
@@ -24,11 +19,7 @@ func x() {
 -- top_level.out.go --
 package foo
 
-import (
-	"context"
-
-	"golang.org/x/net/context"
-)
+import "context"
 
 func x() {
 	context.Background()
@@ -53,8 +44,6 @@ package foo
 import (
 	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func x() {

--- a/testdata/rewrite_import_paths
+++ b/testdata/rewrite_import_paths
@@ -61,7 +61,7 @@ func z() {
 -- no_named_import.out.go --
 package baz
 
-import fooclient "foo-client"
+import "foo-client"
 
 func z() {
 	fooclient.NewRequest()


### PR DESCRIPTION
Users previously had to work around the limitation that a named import in a
patch would transform an unnamed import to a named import.

That is,

```diff
@@
var foo, X identifier
@@
-import foo "example.com/foo"
+import foo "example.com/foo/v2"

 foo.X
```

Would transform unnamed imports in matched files to named imports:

```diff
package thing

-import "example.com/foo"
+import foo "example.com/foo/v2"
```

This was undesirable.

Teach the import matcher and replacer to recognize that the matched import
is unnamed, and remember that for later, associating it with the
metavariable name, not the import path. Associating it with the import path
would make it impossible to rename import paths like the case above.

The implementaton is a bit messy, but we basically have to differentiate
between the package name of an import and the identifier we use to refer to
types defined in that import.

Resolves #2
