### PR TITLE
import/unnamed: Avoid duplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - ([#2]): Patches with named imports now support matching and manipulating any
   import.
+- Fix issue where rewrites of unnamed imports would end up with duplicate
+  entries.
 
   [#2]: https://github.com/uber-go/gopatch/issues/2
 

--- a/internal/engine/import.go
+++ b/internal/engine/import.go
@@ -245,6 +245,10 @@ func (r ImportReplacer) Replace(d data.Data, cl Changelog, f *ast.File) (string,
 			pkgName = name
 		}
 
+	} else {
+		// TODO: more sophisticated package name guessing logic here
+		// and below.
+		pkgName = filepath.Base(r.Path)
 	}
 
 	if !astutil.AddNamedImport(r.Fset, f, name, r.Path) {

--- a/testdata/name_and_rewrite_unnamed_import
+++ b/testdata/name_and_rewrite_unnamed_import
@@ -1,0 +1,27 @@
+-- in.patch --
+@@
+var x identifier
+@@
+-import "example.com/foo-go.git"
++import foo "example.com/foo"
+
+ foo.x
+
+-- user.in.go --
+package user
+
+import "example.com/foo-go.git"
+
+func stuff() {
+	foo.Do()
+}
+
+-- user.out.go --
+package user
+
+import foo "example.com/foo"
+
+func stuff() {
+	foo.Do()
+}
+

--- a/testdata/rename_unnamed_import
+++ b/testdata/rename_unnamed_import
@@ -1,0 +1,27 @@
+-- in.patch --
+@@
+var x identifier
+@@
+
+-import "github.com/fake/lib"
++import "github.com/totallyreal/lib"
+
+ lib.x
+
+-- unnamed.in.go --
+package main
+
+import "github.com/fake/lib"
+
+func foo() {
+	lib.Bar()
+}
+
+-- unnamed.out.go --
+package main
+
+import "github.com/totallyreal/lib"
+
+func foo() {
+	lib.Bar()
+}


### PR DESCRIPTION
When rewriting unnamed imports like so, gopatch would sometimes fail to
delete the old import because it didn't realize that that import was no
longer used.

```
@@
var X identifier
@@
-import "example.com/foo/internal/lib"
+import "example.com/foo/lib"

  lib.X
```

This is because when detecting whether the import has been replaced, it
recorded the package name for the old import as unknown.

This changes it to guess the package name for the old import based on its
basename.

Caveat: Like the other place where we guess package names for unnamed
imports, this won't work when the package name doesn't match basename. We
can write a best effort heuristic for this, but I think our recommendation
here more generally should be to recommend a patch with a named import
metavariable so that we can handle both, named and unnamed imports, and
have a good idea of the package name from the patch.
