### PR TITLE
examples: Simplify destutter

### DIFF
--- a/examples/destutter.patch
+++ b/examples/destutter.patch
@@ -6,13 +6,6 @@
 +Client
 
 @@
-@@
- import "example.com/http"
-
--http.HTTPClient
-+http.Client
-
-@@
 var http identifier
 @@
  import http "example.com/http"


### PR DESCRIPTION
The destutter example was working around #2. This is no longer necessary
since #29. testdata/destutter tests this example patch against both,
named and unnamed imports, and the test case remains unchanged.
