### PR TITLE
test/e2e: Always check --diff output

### DIFF
--- a/testdata/add_iface_return
+++ b/testdata/add_iface_return
@@ -46,3 +46,21 @@ func (*bar) Do() error {
 	fmt.Println("hello")
 	return nil
 }
+
+-- a.diff --
+@@ -1,12 +1,13 @@
+ package a
+ 
+ type Foo interface {
+-	Do()
++	Do() error
+ 	String() string
+ }
+ 
+ type bar struct{}
+ 
+-func (*bar) Do() {
++func (*bar) Do() error {
+ 	fmt.Println("hello")
++	return nil
+ }

--- a/testdata/const_to_var
+++ b/testdata/const_to_var
@@ -22,6 +22,15 @@ var (
 	Foo = "hello"
 )
 
+-- top_level.diff --
+@@ -1,5 +1,5 @@
+ package foo
+ 
+-const (
++var (
+ 	Foo = "hello"
+ )
+
 -- nested.in.go --
 package foo
 
@@ -39,6 +48,17 @@ func bar() {
 		Foo = "world"
 	)
 }
+
+-- nested.diff --
+@@ -1,7 +1,7 @@
+ package foo
+ 
+ func bar() {
+-	const (
++	var (
+ 		Foo = "world"
+ 	)
+ }
 
 -- single_top_level.in.go --
 package foo

--- a/testdata/dedupe_args
+++ b/testdata/dedupe_args
@@ -21,6 +21,16 @@ func bar() {
 	foo(v, v)
 }
 
+-- foo.diff --
+@@ -1,5 +1,6 @@
+ package foo
+ 
+ func bar() {
+-	foo(x + 1, x + 1)
++	v := x + 1
++	foo(v, v)
+ }
+
 -- bar.in.go --
 package bar
 
@@ -35,3 +45,13 @@ func baz() {
 	v := getValue()
 	foo(v, v)
 }
+
+-- bar.diff --
+@@ -1,5 +1,6 @@
+ package bar
+ 
+ func baz() {
+-	foo(getValue(), getValue())
++	v := getValue()
++	foo(v, v)
+ }

--- a/testdata/defer_return
+++ b/testdata/defer_return
@@ -34,3 +34,15 @@ func X() {
 	mutex.Unlock()
 	return r
 }
+
+-- mutex.diff --
+@@ -2,6 +2,7 @@
+ 
+ func X() {
+ 	mutex.Lock()
+-	defer mutex.Unlock()
+-	return calculate()
++	r := calculate()
++	mutex.Unlock()
++	return r
+ }

--- a/testdata/delete_any_import
+++ b/testdata/delete_any_import
@@ -22,6 +22,16 @@ func x() {
 	bar()
 }
 
+-- unnamed.diff --
+@@ -1,7 +1,5 @@
+ package x
+ 
+-import "foo"
+-
+ func x() {
+ 	bar()
+ }
+
 -- named.in.go --
 package x
 
@@ -37,3 +47,13 @@ package x
 func x() {
 	bar()
 }
+
+-- named.diff --
+@@ -1,7 +1,5 @@
+ package x
+ 
+-import baz "foo"
+-
+ func x() {
+ 	bar()
+ }

--- a/testdata/delete_dots
+++ b/testdata/delete_dots
@@ -48,3 +48,30 @@ func zzz() {
 	baz()
 	qux()
 }
+
+-- stuff.diff --
+@@ -1,12 +1,6 @@
+ package stuff
+ 
+ func zzz() {
+-	foo()
+-
+-	if err := x(); err != nil {
+-		panic(err)
+-	}
+-
+ 	bar()
+ 
+ 	if err := y(); err != nil {
+@@ -14,11 +8,5 @@
+ 	}
+ 
+ 	baz()
+-
+-	if err := y(); err != nil {
+-		// This should be deleted.
+-		panic(err)
+-	}
+-
+ 	qux()
+ }

--- a/testdata/delete_field
+++ b/testdata/delete_field
@@ -37,6 +37,17 @@ func bar() {
 	})
 }
 
+-- named.diff --
+@@ -5,7 +5,7 @@
+ func bar() {
+ 	foogit.Initialize(foogit.Params{
+ 		Name: "name",
+-		Foo: foogit.GetClient(),
++
+ 		Value: "bar",
+ 	})
+ }
+
 -- unnamed.in.go --
 package a
 
@@ -62,3 +73,14 @@ func bar() {
 		Value: "bar",
 	})
 }
+
+-- unnamed.diff --
+@@ -5,7 +5,7 @@
+ func bar() {
+ 	foo.Initialize(foo.Params{
+ 		Name: "name",
+-		Foo: foo.GetClient(),
++
+ 		Value: "bar",
+ 	})
+ }

--- a/testdata/delete_struct_field
+++ b/testdata/delete_struct_field
@@ -37,3 +37,18 @@ type Foo struct {
 
 type Bar struct {
 }
+
+-- delete.diff --
+@@ -2,12 +2,10 @@
+ 
+ type Foo struct {
+ 	A string
+-	B *Deprecated
+ 
+ 	// C does stuff.
+ 	C int
+ }
+ 
+ type Bar struct {
+-	d *Deprecated
+ }

--- a/testdata/destutter
+++ b/testdata/destutter
@@ -43,6 +43,28 @@ func (c *Client) Do(
 	return c.client.Do(r.WithContext(ctx))
 }
 
+-- http_client.diff --
+@@ -2,15 +2,15 @@
+ 
+ import "net/http"
+ 
+-type HTTPClient struct {
++type Client struct {
+ 	client *http.Client
+ }
+ 
+-func New(c *http.Client) *HTTPClient {
+-	return &HTTPClient{c}
++func New(c *http.Client) *Client {
++	return &Client{c}
+ }
+ 
+-func (c *HTTPClient) Do(
++func (c *Client) Do(
+ 	ctx context.Context,
+ 	r *http.Request,
+ ) (*http.Response, error) {
+
 -- unqualified_import.in.go --
 package foo
 
@@ -69,6 +91,17 @@ func doStuff(client *http.Client) err {
 	return res.Body.Close()
 }
 
+-- unqualified_import.diff --
+@@ -2,7 +2,7 @@
+ 
+ import "example.com/http"
+ 
+-func doStuff(client *http.HTTPClient) err {
++func doStuff(client *http.Client) err {
+ 	res, err := client.Do(getRequest())
+ 	if err != nil {
+ 		return err
+
 -- qualified_import.in.go --
 package bar
 
@@ -94,3 +127,13 @@ import (
 func buildClient(c *http.Client) *myhttp.Client {
 	return myhttp.New(c)
 }
+
+-- qualified_import.diff --
+@@ -6,6 +6,6 @@
+ 	myhttp "example.com/http"
+ )
+ 
+-func buildClient(c *http.Client) *myhttp.HTTPClient {
++func buildClient(c *http.Client) *myhttp.Client {
+ 	return myhttp.New(c)
+ }

--- a/testdata/dts_in_args
+++ b/testdata/dts_in_args
@@ -19,3 +19,12 @@ package a
 func name(foo string, thingOne string, thingTwo func(...string) string, bar int) string {
 	return "very valid go"
 }
+
+-- dts_in_args.diff --
+@@ -1,5 +1,5 @@
+ package a
+ 
+-func name(foo string, bar int, thingOne string, thingTwo func(...string) string) string {
++func name(foo string, thingOne string, thingTwo func(...string) string, bar int) string {
+ 	return "very valid go"
+ }

--- a/testdata/dts_in_receiver
+++ b/testdata/dts_in_receiver
@@ -19,3 +19,12 @@ package a
 func (r *Receiver) name(bar string) string {
 	return "very valid go"
 }
+
+-- has_receiver.diff --
+@@ -1,5 +1,5 @@
+ package a
+ 
+-func (r *Receiver) name(foo string) string {
++func (r *Receiver) name(bar string) string {
+ 	return "very valid go"
+ }

--- a/testdata/dts_in_results
+++ b/testdata/dts_in_results
@@ -21,6 +21,16 @@ func name(foo string, bar int) (string, error) {
 	return "very valid go", nil
 }
 
+-- unnamed.diff --
+@@ -1,5 +1,5 @@
+ package a
+ 
+-func name(foo string, bar int) (error, string) {
+-	return nil, "very valid go"
++func name(foo string, bar int) (string, error) {
++	return "very valid go", nil
+ }
+
 -- named.patch --
 @@
 @@
@@ -43,3 +53,13 @@ package a
 func name(foo string, bar int) (val string, err error) {
 	return "very valid go", nil
 }
+
+-- named.diff --
+@@ -1,5 +1,5 @@
+ package a
+ 
+-func name(foo string, bar int) (err error, val string) {
+-	return nil, "very valid go"
++func name(foo string, bar int) (val string, err error) {
++	return "very valid go", nil
+ }

--- a/testdata/embed_to_field
+++ b/testdata/embed_to_field
@@ -27,3 +27,14 @@ type User struct {
 
 	Name string
 }
+
+-- a.diff --
+@@ -1,7 +1,7 @@
+ package a
+ 
+ type User struct {
+-	Person
++	Person Person
+ 
+ 	Name string
+ }

--- a/testdata/foo_call_to_bar
+++ b/testdata/foo_call_to_bar
@@ -18,3 +18,12 @@ package main
 func main() {
 	bar(42)
 }
+
+-- simple.diff --
+@@ -1,5 +1,5 @@
+ package main
+ 
+ func main() {
+-	foo(42)
++	bar(42)
+ }

--- a/testdata/func_within_a_func
+++ b/testdata/func_within_a_func
@@ -34,6 +34,17 @@ func foo(close func(*log.Logger) error) string {
 	return "very valid go"
 }
 
+-- one_dots.diff --
+@@ -5,7 +5,7 @@
+ 	"os"
+ )
+ 
+-func foo(close func(*log.Logger)) string {
++func foo(close func(*log.Logger) error) string {
+ 	logger := log.New(os.Stdout, name, 0)
+ 	defer close(logger)
+ 	return "very valid go"
+
 -- two_dots.patch --
 @@
 @@

--- a/testdata/generic_instantiation
+++ b/testdata/generic_instantiation
@@ -24,3 +24,16 @@ func baz() {
 	bar[[]byte]([]byte("hello"))
 	bar[List[int]](nil)
 }
+
+-- a.diff --
+@@ -1,7 +1,7 @@
+ package a
+ 
+ func baz() {
+-	foo[int](42)
+-	foo[[]byte]([]byte("hello"))
+-	foo[List[int]](nil)
++	bar[int](42)
++	bar[[]byte]([]byte("hello"))
++	bar[List[int]](nil)
+ }

--- a/testdata/generics_in_src
+++ b/testdata/generics_in_src
@@ -32,3 +32,18 @@ func baz() {
 	bar[int](42)
 }
 
+
+-- a.diff --
+@@ -2,10 +2,10 @@
+ 
+ import "fmt"
+ 
+-func foo[T any](x T) {
++func bar[T any](x T) {
+ 	fmt.Println(x)
+ }
+ 
+ func baz() {
+-	foo[int](42)
++	bar[int](42)
+ }

--- a/testdata/httpclient_use_ctx
+++ b/testdata/httpclient_use_ctx
@@ -80,3 +80,20 @@ func getResponse(ctx context.Context, req *http.Request) (*http.Response, error)
 	res, err := http.DefaultClient.Do(req)
 	return res, err
 }
+
+-- two_returns.diff --
+@@ -1,8 +1,12 @@
+ package main
+ 
+-import "net/http"
++import (
++	"context"
++	"net/http"
++)
+ 
+-func getResponse(req *http.Request) (*http.Response, error) {
++func getResponse(ctx context.Context, req *http.Request) (*http.Response, error) {
++	req = req.WithContext(ctx)
+ 	res, err := http.DefaultClient.Do(req)
+ 	return res, err
+ }

--- a/testdata/if_to_for
+++ b/testdata/if_to_for
@@ -26,3 +26,14 @@ func x() {
 		bar() // qux
 	}
 }
+
+-- x.diff --
+@@ -1,7 +1,7 @@
+ package foo
+ 
+ func x() {
+-	if true {
++	for true {
+ 		foo() // baz
+ 		bar() // qux
+ 	}

--- a/testdata/import_grouping
+++ b/testdata/import_grouping
@@ -37,3 +37,20 @@ import (
 func Foo(context.Context) error {
 	return errors.New("foo")
 }
+
+-- foo.diff --
+@@ -2,12 +2,12 @@
+ 
+ import (
+ 	"context"
+-	"fmt"
++	"errors"
+ 
+ 	"code.mycompany.com/foo"
+ )
+ 
+ // Foo does stuff.
+ func Foo(context.Context) error {
+-	return fmt.Errorf("foo")
++	return errors.New("foo")
+ }

--- a/testdata/inline_err_assignments
+++ b/testdata/inline_err_assignments
@@ -33,6 +33,18 @@ func bar() (*Result, error) {
 }
 
 
+-- multiple.diff --
+@@ -2,8 +2,7 @@
+ 
+ func bar() (*Result, error) {
+ 	// Test.
+-	err = baz()
+-	if err != nil {
++	if err := baz(); err != nil {
+ 		return nil, err
+ 	}
+ 	return &Result{}, nil
+
 -- single.in.go --
 package foo
 
@@ -55,3 +67,15 @@ func bar() error {
 	}
 	return nil
 }
+
+-- single.diff --
+@@ -2,8 +2,7 @@
+ 
+ func bar() error {
+ 	// Test.
+-	err = baz()
+-	if err != nil {
++	if err := baz(); err != nil {
+ 		return err
+ 	}
+ 	return nil

--- a/testdata/inline_errors
+++ b/testdata/inline_errors
@@ -52,6 +52,18 @@ func bar() (Result, error) {
 	return Result{}, nil
 }
 
+-- match.diff --
+@@ -2,8 +2,7 @@
+ 
+ func bar() (Result, error) {
+ 	// Test.
+-	err := baz()
+-	if err != nil {
++	if err := baz(); err != nil {
+ 		// Hello.
+ 		log()
+ 		return nil, err
+
 -- no_match.in.go --
 package foo
 
@@ -106,6 +118,23 @@ func qux() {
 	}
 }
 
+-- else.diff --
+@@ -1,12 +1,10 @@
+ package foo
+ 
+ func qux() {
+-	err := foo()
+-	if err != nil {
++	if err := foo(); err != nil {
+ 		return
+ 	} else {
+-		err2 := quux()
+-		if err2 != nil {
++		if err2 := quux(); err2 != nil {
+ 			return
+ 		}
+ 	}
+
 -- case.in.go --
 package foo
 
@@ -133,6 +162,18 @@ func foo() error {
 	return nil
 }
 
+-- case.diff --
+@@ -3,8 +3,7 @@
+ func foo() error {
+ 	switch bar() {
+ 	case "x":
+-		err := baz()
+-		if err != nil {
++		if err := baz(); err != nil {
+ 			return err
+ 		}
+ 	}
+
 -- select.in.go --
 package foo
 
@@ -159,3 +200,15 @@ func foo(ctx context.Context) error {
 	}
 	return nil
 }
+
+-- select.diff --
+@@ -3,8 +3,7 @@
+ func foo(ctx context.Context) error {
+ 	select {
+ 	case <-ctx.Done():
+-		err := ctx.Err()
+-		if err != nil {
++		if err := ctx.Err(); err != nil {
+ 			return err
+ 		}
+ 	}

--- a/testdata/match_named_import
+++ b/testdata/match_named_import
@@ -48,3 +48,15 @@ import bar "example.com/bar"
 func stuff() {
 	bar.stuff()
 }
+
+-- named.diff --
+@@ -1,7 +1,7 @@
+ package whatever
+ 
+-import foo "example.com/bar"
++import bar "example.com/bar"
+ 
+ func stuff() {
+-	foo.stuff()
++	bar.stuff()
+ }

--- a/testdata/matches_test_files
+++ b/testdata/matches_test_files
@@ -20,6 +20,15 @@ func y() {
 	bar()
 }
 
+-- foo.diff --
+@@ -1,5 +1,5 @@
+ package x
+ 
+ func y() {
+-	foo()
++	bar()
+ }
+
 -- foo_test.in.go --
 package x
 
@@ -37,3 +46,12 @@ import "testing"
 func TestThing(t *testing.T) {
 	bar()
 }
+
+-- foo_test.diff --
+@@ -3,5 +3,5 @@
+ import "testing"
+ 
+ func TestThing(t *testing.T) {
+-	foo()
++	bar()
+ }

--- a/testdata/name_and_rewrite_unnamed_import
+++ b/testdata/name_and_rewrite_unnamed_import
@@ -25,3 +25,13 @@ func stuff() {
 	foo.Do()
 }
 
+
+-- user.diff --
+@@ -1,6 +1,6 @@
+ package user
+ 
+-import "example.com/foo-go.git"
++import foo "example.com/foo"
+ 
+ func stuff() {
+ 	foo.Do()

--- a/testdata/name_unnamed_import
+++ b/testdata/name_unnamed_import
@@ -24,3 +24,13 @@ import foo "example.com/foo-go.git"
 func stuff() {
 	foo.Do()
 }
+
+-- user.diff --
+@@ -1,6 +1,6 @@
+ package user
+ 
+-import "example.com/foo-go.git"
++import foo "example.com/foo-go.git"
+ 
+ func stuff() {
+ 	foo.Do()

--- a/testdata/nil_safe_string
+++ b/testdata/nil_safe_string
@@ -36,3 +36,14 @@ func (b *Bar) String() string {
 	}
 	return b.Name
 }
+
+-- foo.diff --
+@@ -5,5 +5,8 @@
+ }
+ 
+ func (b *Bar) String() string {
++	if b == nil {
++		return "<nil>"
++	}
+ 	return b.Name
+ }

--- a/testdata/noop_import
+++ b/testdata/noop_import
@@ -49,6 +49,26 @@ func foo(s string) *bool {
 	return ptr.Bool(true)
 }
 
+-- remove_all.diff --
+@@ -1,13 +1,11 @@
+ package main
+ 
+-import (
+-	"conversion/to.git"
+-)
++import "go.uber.org/thriftrw/ptr"
+ 
+ func foo(s string) *bool {
+-	if to.StrPtr(s) == nil {
+-		return to.BoolPtr(false)
++	if ptr.String(s) == nil {
++		return ptr.Bool(false)
+ 	}
+ 
+-	return to.BoolPtr(true)
++	return ptr.Bool(true)
+ }
+
 -- remove_some.in.go --
 package main
 
@@ -88,3 +108,28 @@ func foo(s string) *bool {
 
 	return ptr.Bool(true)
 }
+
+-- remove_some.diff --
+@@ -2,16 +2,18 @@
+ 
+ import (
+ 	"conversion/to.git"
++
++	"go.uber.org/thriftrw/ptr"
+ )
+ 
+ func foo(s string) *bool {
+-	if to.StrPtr(s) == nil {
+-		return to.BoolPtr(false)
++	if ptr.String(s) == nil {
++		return ptr.Bool(false)
+ 	}
+ 
+ 	if to.DecimalPtr(s) == nil {
+-		return to.BoolPtr(false)
++		return ptr.Bool(false)
+ 	}
+ 
+-	return to.BoolPtr(true)
++	return ptr.Bool(true)
+ }

--- a/testdata/optimize_string_appends
+++ b/testdata/optimize_string_appends
@@ -51,3 +51,23 @@ func run() string {
 
 	return s
 }
+
+-- loop.diff --
+@@ -1,11 +1,15 @@
+ package foo
+ 
++import "strings"
++
+ func run() string {
+-	var s string
++	var sb strings.Builder
+ 	for i := range foo(true /* bar */) {
+ 		x := foo()
+-		s += x
++		sb.WriteString(x)
+ 		log(x)
+ 	}
++	s := sb.String()
++
+ 	return s
+ }

--- a/testdata/recognize_all_imports
+++ b/testdata/recognize_all_imports
@@ -25,6 +25,16 @@ func foo() {
 	foo.X()
 }
 
+-- unnamed.diff --
+@@ -1,6 +1,6 @@
+ package whatever
+ 
+-import "example.com/foo-go.git"
++import "example.com/foo.git"
+ 
+ func foo() {
+ 	foo.X()
+
 -- named.in.go --
 package whatever
 
@@ -42,3 +52,13 @@ import bar "example.com/foo.git"
 func foo() {
 	bar.X()
 }
+
+-- named.diff --
+@@ -1,6 +1,6 @@
+ package whatever
+ 
+-import bar "example.com/foo-go.git"
++import bar "example.com/foo.git"
+ 
+ func foo() {
+ 	bar.X()

--- a/testdata/redundant_fmt_errorf
+++ b/testdata/redundant_fmt_errorf
@@ -30,6 +30,18 @@ func Do() error {
 	return errors.New("great sadness")
 }
 
+-- replace.diff --
+@@ -1,7 +1,7 @@
+ package foo
+ 
+-import "fmt"
++import "errors"
+ 
+ func Do() error {
+-	return fmt.Errorf("great sadness")
++	return errors.New("great sadness")
+ }
+
 -- leave_sprintf.in.go --
 package bar
 
@@ -54,3 +66,20 @@ const _thing = "thing"
 func Do() error {
 	return errors.New(fmt.Sprintf("%v failed", _thing))
 }
+
+-- leave_sprintf.diff --
+@@ -1,9 +1,12 @@
+ package bar
+ 
+-import "fmt"
++import (
++	"errors"
++	"fmt"
++)
+ 
+ const _thing = "thing"
+ 
+ func Do() error {
+-	return fmt.Errorf(fmt.Sprintf("%v failed", _thing))
++	return errors.New(fmt.Sprintf("%v failed", _thing))
+ }

--- a/testdata/remove_context_field
+++ b/testdata/remove_context_field
@@ -21,6 +21,14 @@ package alone
 type Request struct {
 }
 
+-- alone.diff --
+@@ -1,5 +1,4 @@
+ package alone
+ 
+ type Request struct {
+-	Context context.Context
+ }
+
 -- triple.in.go --
 package triple
 
@@ -38,3 +46,13 @@ type Request struct {
 
 	Time time.Duration
 }
+
+-- triple.diff --
+@@ -2,6 +2,6 @@
+ 
+ type Request struct {
+ 	User string
+-	Ctxt context.Context
++
+ 	Time time.Duration
+ }

--- a/testdata/rename_named_import
+++ b/testdata/rename_named_import
@@ -27,3 +27,17 @@ func stuff() {
 	var a baz.Bar
 	baz.Init(&a)
 }
+
+-- a.diff --
+@@ -1,8 +1,8 @@
+ package a
+ 
+-import foo "bar"
++import baz "bar"
+ 
+ func stuff() {
+-	var a foo.Bar
+-	foo.Init(&a)
++	var a baz.Bar
++	baz.Init(&a)
+ }

--- a/testdata/rename_package
+++ b/testdata/rename_package
@@ -25,3 +25,11 @@ import "fmt"
 func main() {
 	Foo()
 }
+
+-- foo.diff --
+@@ -1,4 +1,4 @@
+-package foo
++package bar
+ 
+ import "fmt"
+ 

--- a/testdata/rename_unnamed_import
+++ b/testdata/rename_unnamed_import
@@ -25,3 +25,13 @@ import "github.com/totallyreal/lib"
 func foo() {
 	lib.Bar()
 }
+
+-- unnamed.diff --
+@@ -1,6 +1,6 @@
+ package main
+ 
+-import "github.com/fake/lib"
++import "github.com/totallyreal/lib"
+ 
+ func foo() {
+ 	lib.Bar()

--- a/testdata/replace_any_import_with_unnamed
+++ b/testdata/replace_any_import_with_unnamed
@@ -26,6 +26,18 @@ func main() {
 	compat.Init()
 }
 
+-- unnamed.diff --
+@@ -1,7 +1,7 @@
+ package main
+ 
+-import "example.com/foo/client"
++import "example.com/foo-client/compat"
+ 
+ func main() {
+-	fooclient.Init()
++	compat.Init()
+ }
+
 -- named.in.go --
 package main
 
@@ -43,3 +55,15 @@ import "example.com/foo-client/compat"
 func main() {
 	compat.Init()
 }
+
+-- named.diff --
+@@ -1,7 +1,7 @@
+ package main
+ 
+-import client "example.com/foo/client"
++import "example.com/foo-client/compat"
+ 
+ func main() {
+-	client.Init()
++	compat.Init()
+ }

--- a/testdata/replace_import_with_top_level_comment
+++ b/testdata/replace_import_with_top_level_comment
@@ -30,3 +30,16 @@ import "github.com/foo/bar/internal/edit"
 func main() {
 	_ = edit.Buffer
 }
+
+-- comment.diff --
+@@ -2,9 +2,7 @@
+ 
+ package main
+ 
+-import (
+-	"cmd/internal/edit"
+-)
++import "github.com/foo/bar/internal/edit"
+ 
+ func main() {
+ 	_ = edit.Buffer

--- a/testdata/replace_net_context
+++ b/testdata/replace_net_context
@@ -25,6 +25,16 @@ func x() {
 	context.Background()
 }
 
+-- top_level.diff --
+@@ -1,6 +1,6 @@
+ package foo
+ 
+-import "golang.org/x/net/context"
++import "context"
+ 
+ func x() {
+ 	context.Background()
+
 -- import_group.in.go --
 package foo
 
@@ -49,3 +59,16 @@ import (
 func x() {
 	context.WithTimeout(context.Background(), time.Second)
 }
+
+-- import_group.diff --
+@@ -1,9 +1,8 @@
+ package foo
+ 
+ import (
++	"context"
+ 	"time"
+-
+-	"golang.org/x/net/context"
+ )
+ 
+ func x() {

--- a/testdata/return_err
+++ b/testdata/return_err
@@ -19,3 +19,12 @@ package foo
 func bar() error {
 	return nil
 }
+
+-- foo.diff --
+@@ -1,4 +1,5 @@
+ package foo
+ 
+-func bar() {
++func bar() error {
++	return nil
+ }

--- a/testdata/rewrite_import_paths
+++ b/testdata/rewrite_import_paths
@@ -29,6 +29,16 @@ func x() {
 	client.SendRequest(fooclient.NewRequest())
 }
 
+-- has_same_named_import.diff --
+@@ -1,6 +1,6 @@
+ package bar
+ 
+-import fooclient "foo-go/client"
++import fooclient "foo-client"
+ 
+ func x() {
+ 	var client fooclient.Interface
+
 -- has_different_named_import.in.go --
 package baz
 
@@ -49,6 +59,16 @@ func y() {
 	c.SendRequest(client.NewRequest())
 }
 
+-- has_different_named_import.diff --
+@@ -1,6 +1,6 @@
+ package baz
+ 
+-import client "foo-go/client"
++import client "foo-client"
+ 
+ func y() {
+ 	c := client.New()
+
 -- no_named_import.in.go --
 package baz
 
@@ -66,3 +86,13 @@ import "foo-client"
 func z() {
 	fooclient.NewRequest()
 }
+
+-- no_named_import.diff --
+@@ -1,6 +1,6 @@
+ package baz
+ 
+-import "foo-go/client"
++import "foo-client"
+ 
+ func z() {
+ 	fooclient.NewRequest()

--- a/testdata/s1012
+++ b/testdata/s1012
@@ -40,3 +40,12 @@ func main() {
 
 	fmt.Println("elapsed time:", time.Since(start))
 }
+
+-- example.diff --
+@@ -13,5 +13,5 @@
+ 		log.Fatal(err)
+ 	}
+ 
+-	fmt.Println("elapsed time:", time.Now().Sub(start))
++	fmt.Println("elapsed time:", time.Since(start))
+ }

--- a/testdata/s1028
+++ b/testdata/s1028
@@ -23,3 +23,18 @@ import "fmt"
 func bar(i int) error {
 	return fmt.Errorf("great sadness: %d", i)
 }
+
+-- foo.diff --
+@@ -1,10 +1,7 @@
+ package foo
+ 
+-import (
+-	"fmt"
+-	"errors"
+-)
++import "fmt"
+ 
+ func bar(i int) error {
+-	return errors.New(fmt.Sprintf("great sadness: %d", i))
++	return fmt.Errorf("great sadness: %d", i)
+ }

--- a/testdata/s1038
+++ b/testdata/s1038
@@ -20,3 +20,12 @@ import "fmt"
 func foo() {
 	fmt.Printf("thing happend: %v", thing())
 }
+
+-- example.diff --
+@@ -3,5 +3,5 @@
+ import "fmt"
+ 
+ func foo() {
+-	fmt.Print(fmt.Sprintf("thing happend: %v", thing()))
++	fmt.Printf("thing happend: %v", thing())
+ }

--- a/testdata/slice_and_import
+++ b/testdata/slice_and_import
@@ -25,3 +25,14 @@ import "example.com/constants"
 func items() []string {
 	return []string{"a", "b", constants.Foo, "bar", "d"}
 }
+
+-- foo.diff --
+@@ -1,5 +1,7 @@
+ package foo
+ 
++import "example.com/constants"
++
+ func items() []string {
+-	return []string{"a", "b", "foo", "bar", "d"}
++	return []string{"a", "b", constants.Foo, "bar", "d"}
+ }

--- a/testdata/stmt_to_expr
+++ b/testdata/stmt_to_expr
@@ -17,3 +17,12 @@ package a
 func b() {
 	bar()
 }
+
+-- a.diff --
+@@ -1,5 +1,5 @@
+ package a
+ 
+ func b() {
+-	x := foo()
++	bar()
+ }

--- a/testdata/string_builder_for_loop
+++ b/testdata/string_builder_for_loop
@@ -42,6 +42,24 @@ func foo() string {
 	// TODO: return string; unsupported right now.
 }
 
+-- for_loop_three_clauses.diff --
+@@ -1,9 +1,13 @@
+ package foo
+ 
++import "strings"
++
+ func foo() string {
+-	var x string
++	var sb strings.Builder
+ 	for s := next(); s != ""; s = next() {
+-		x += s
++		sb.WriteString(s)
+ 	}
++	x := sb.String()
++
+ 	// TODO: return string; unsupported right now.
+ }
+
 -- for_loop_one_clause.in.go --
 package bar
 
@@ -65,6 +83,23 @@ func bar() {
 	x := sb.String()
 
 }
+
+-- for_loop_one_clause.diff --
+@@ -1,8 +1,12 @@
+ package bar
+ 
++import "strings"
++
+ func bar() {
+-	var x string
++	var sb strings.Builder
+ 	for condition() {
+-		x += next()
++		sb.WriteString(next())
+ 	}
++	x := sb.String()
++
+ }
 
 -- range_one_result.in.go --
 package baz
@@ -95,6 +130,27 @@ func baz() {
 
 }
 
+-- range_one_result.diff --
+@@ -1,10 +1,15 @@
+ package baz
+ 
+-import "fmt"
++import (
++	"fmt"
++	"strings"
++)
+ 
+ func baz() {
+-	var a string
++	var sb strings.Builder
+ 	for x := range y() {
+-		a += fmt.Sprintf("<%q>", x)
++		sb.WriteString(fmt.Sprintf("<%q>", x))
+ 	}
++	a := sb.String()
++
+ }
+
 -- range_two_results.in.go --
 package qux
 
@@ -118,6 +174,23 @@ func qux() {
 	a := sb.String()
 
 }
+
+-- range_two_results.diff --
+@@ -1,8 +1,12 @@
+ package qux
+ 
++import "strings"
++
+ func qux() {
+-	var a string
++	var sb strings.Builder
+ 	for k, v := range something() {
+-		a += k + ": " + v
++		sb.WriteString(k + ": " + v)
+ 	}
++	a := sb.String()
++
+ }
 
 -- range_no_results.in.go --
 package quux
@@ -148,6 +221,27 @@ func quux() {
 
 }
 
+-- range_no_results.diff --
+@@ -1,10 +1,15 @@
+ package quux
+ 
+-import "time"
++import (
++	"strings"
++	"time"
++)
+ 
+ func quux() {
+-	var infinity string
++	var sb strings.Builder
+ 	for range time.Tick(time.Millisecond) {
+-		infinity += "∞"
++		sb.WriteString("∞")
+ 	}
++	infinity := sb.String()
++
+ }
+
 -- range_assign.in.go --
 package quuz
 
@@ -171,3 +265,20 @@ func quuz() {
 	a := sb.String()
 
 }
+
+-- range_assign.diff --
+@@ -1,8 +1,12 @@
+ package quuz
+ 
++import "strings"
++
+ func quuz() {
+-	var a string
++	var sb strings.Builder
+ 	for x = range y() {
+-		a += x
++		sb.WriteString(x)
+ 	}
++	a := sb.String()
++
+ }

--- a/testdata/string_repeat
+++ b/testdata/string_repeat
@@ -32,3 +32,17 @@ func do() {
 	s := strings.Repeat("x", getCount())
 }
 
+
+-- buffer.diff --
+@@ -1,8 +1,7 @@
+ package foo
+ 
++import "strings"
++
+ func do() {
+-	var s string
+-	for n := 0; n < getCount(); n++ {
+-		s += "x"
+-	}
++	s := strings.Repeat("x", getCount())
+ }

--- a/testdata/struct_decl_field_rename
+++ b/testdata/struct_decl_field_rename
@@ -25,3 +25,16 @@ type User struct {
 	Name  string
 	ID    UUID
 }
+
+-- middle.diff --
+@@ -1,7 +1,7 @@
+ package foo
+ 
+ type User struct {
+-	Email    string
+-	UserName string
+-	ID       UUID
++	Email string
++	Name  string
++	ID    UUID
+ }

--- a/testdata/struct_field_pair
+++ b/testdata/struct_field_pair
@@ -23,3 +23,13 @@ package main
 type Config struct {
 	Mods, Admins []string
 }
+
+-- config.diff --
+@@ -1,6 +1,5 @@
+ package main
+ 
+ type Config struct {
+-	Mods   []string
+-	Admins []string
++	Mods, Admins []string
+ }

--- a/testdata/struct_init_field_rename
+++ b/testdata/struct_init_field_rename
@@ -29,6 +29,17 @@ func thing() {
 	})
 }
 
+-- first.diff --
+@@ -2,7 +2,7 @@
+ 
+ func thing() {
+ 	do(User{
+-		Name:  "foo",
++		ID:    "foo",
+ 		Email: "foo@example.com",
+ 	})
+ }
+
 -- middle.in.go --
 package foo
 
@@ -50,3 +61,14 @@ func thing() {
 		Email: "foo@example.com",
 	})
 }
+
+-- middle.diff --
+@@ -3,7 +3,7 @@
+ func thing() {
+ 	do(User{
+ 		Role:  Moderator,
+-		Name:  "foo",
++		ID:    "foo",
+ 		Email: "foo@example.com",
+ 	})
+ }

--- a/testdata/type_to_alias
+++ b/testdata/type_to_alias
@@ -16,3 +16,10 @@ type UUID string
 package x
 
 type UUID = string
+
+-- top_level.diff --
+@@ -1,3 +1,3 @@
+ package x
+ 
+-type UUID string
++type UUID = string

--- a/testdata/unnamed_import_to_named
+++ b/testdata/unnamed_import_to_named
@@ -26,3 +26,13 @@ func foo() {
 	var x bar.Baz
 	x.Do(bar.Option())
 }
+
+-- match.diff --
+@@ -1,6 +1,6 @@
+ package a
+ 
+-import "foo/bar.git"
++import bar "foo/bar.git"
+ 
+ func foo() {
+ 	var x bar.Baz

--- a/testdata/value_group
+++ b/testdata/value_group
@@ -23,6 +23,16 @@ var (
 	foo = bar + 1
 )
 
+-- top_level.diff --
+@@ -1,6 +1,6 @@
+ package a
+ 
+ var (
+-	foo = 43
+ 	bar = 42
++	foo = bar + 1
+ )
+
 -- func.in.go --
 package a
 
@@ -44,3 +54,15 @@ func foo() {
 	)
 	fmt.Println(foo, bar)
 }
+
+-- func.diff --
+@@ -2,8 +2,8 @@
+ 
+ func foo() {
+ 	var (
+-		foo = 43
+ 		bar = 42
++		foo = bar + 1
+ 	)
+ 	fmt.Println(foo, bar)
+ }

--- a/testdata/writebytes_to_write
+++ b/testdata/writebytes_to_write
@@ -28,3 +28,14 @@ func do() {
 	var buff *bytes.Buffer
 	buff.Write(results())
 }
+
+-- buffer.diff --
+@@ -2,7 +2,5 @@
+ 
+ func do() {
+ 	var buff *bytes.Buffer
+-	for _, c := range results() {
+-		buff.WriteByte(c)
+-	}
++	buff.Write(results())
+ }


### PR DESCRIPTION
Currently, the output of `gopatch --diff` is checked only if the test
case included a `.diff` file.
Long-term, it makes sense to verify this for all integration test cases.

This changes the integration test to verify the output of `--diff` for
all cases,
backfilling output for all existing test cases that were missing
entries.
