### PR TITLE
all: run gofumpt

### DIFF
--- a/internal/astdiff/diff.go
+++ b/internal/astdiff/diff.go
@@ -91,7 +91,6 @@ func (f changeFinder) unchanged(from, to *value) {
 
 func (f changeFinder) changed() {
 	f.cl.Changed(f.Pos, f.End)
-
 }
 
 func (f changeFinder) commentsFor(n *value) (before, after []*ast.Comment) {

--- a/internal/parse/section/section_test.go
+++ b/internal/parse/section/section_test.go
@@ -192,7 +192,8 @@ func TestSplit(t *testing.T) {
 						line(129, "+x(42)"),
 					},
 					Comments: []string{
-						"This patch adds an argument."},
+						"This patch adds an argument.",
+					},
 				},
 			},
 			wantPosInfo: map[token.Pos]posInfo{

--- a/main.go
+++ b/main.go
@@ -72,28 +72,28 @@ func newArgParser() (*flags.Parser, *options) {
 	// The following is more readable than long descriptions in struct
 	// tags.
 
-	parser.FindOptionByLongName("version").Description =
-		"Display the version of gopatch."
+	parser.FindOptionByLongName("version").
+		Description = "Display the version of gopatch."
 
-	parser.FindOptionByLongName("verbose").Description =
-		"Turn on verbose mode that prints whether or not the file was patched " +
-			"for each file found."
+	parser.FindOptionByLongName("verbose").
+		Description = "Turn on verbose mode that prints whether or not the file was patched " +
+		"for each file found."
 
-	parser.FindOptionByLongName("patch").Description =
-		"Path to a patch file specifying the code transformation. " +
-			"Multiple patches may be provided to be applied in-order. " +
-			"If the flag is omitted, a patch will be read from stdin."
+	parser.FindOptionByLongName("patch").
+		Description = "Path to a patch file specifying the code transformation. " +
+		"Multiple patches may be provided to be applied in-order. " +
+		"If the flag is omitted, a patch will be read from stdin."
 
-	parser.FindOptionByLongName("diff").Description =
-		"Print a diff of the proposed changes to stdout but don't modify any files."
+	parser.FindOptionByLongName("diff").
+		Description = "Print a diff of the proposed changes to stdout but don't modify any files."
 
-	parser.FindOptionByLongName("print-only").Description =
-		"Print files to stdout without modifying them."
+	parser.FindOptionByLongName("print-only").
+		Description = "Print files to stdout without modifying them."
 
-	parser.Args()[0].Description =
-		"One or more files or directores containing Go code. " +
-			"When directories are provided, all Go files in them and their " +
-			"descendants will be transformed."
+	parser.Args()[0].
+		Description = "One or more files or directores containing Go code. " +
+		"When directories are provided, all Go files in them and their " +
+		"descendants will be transformed."
 
 	return parser, &opts
 }
@@ -307,7 +307,7 @@ func run(args []string, stdin io.Reader, stderr io.Writer, stdout io.Writer) err
 			printComments(comments, stderr)
 			_, err = stdout.Write(bs)
 		default:
-			err = os.WriteFile(filename, bs, 0644)
+			err = os.WriteFile(filename, bs, 0o644)
 		}
 		if err != nil {
 			log.Printf("%s: failed: %v", filename, err)

--- a/main_test.go
+++ b/main_test.go
@@ -74,7 +74,8 @@ func TestNewArgParser(t *testing.T) {
 func TestLoadPatches(t *testing.T) {
 	t.Parallel()
 	t.Run("Success", func(t *testing.T) {
-		opts := &options{Patches: []string{"testdata/patch/error.patch"},
+		opts := &options{
+			Patches:        []string{"testdata/patch/error.patch"},
 			Diff:           true,
 			DisplayVersion: false,
 			Verbose:        false,
@@ -85,7 +86,8 @@ func TestLoadPatches(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("Success - mutiple patches", func(t *testing.T) {
-		opts := &options{Patches: []string{"testdata/patch/error.patch"},
+		opts := &options{
+			Patches:        []string{"testdata/patch/error.patch"},
 			Diff:           true,
 			DisplayVersion: false,
 			Verbose:        false,
@@ -98,7 +100,8 @@ func TestLoadPatches(t *testing.T) {
 	})
 	t.Run("Failure", func(t *testing.T) {
 		path := "testdata/patch/error1.patch"
-		opts := &options{Patches: []string{path},
+		opts := &options{
+			Patches:        []string{path},
 			Diff:           true,
 			DisplayVersion: false,
 			Verbose:        false,
@@ -147,7 +150,6 @@ func TestPreview(t *testing.T) {
 				assert.Equal(t, want, outputString)
 			})
 		}
-
 	})
 
 	t.Run("nil for strings", func(t *testing.T) {

--- a/testdata/test_files/lint_example/time.go
+++ b/testdata/test_files/lint_example/time.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	startOfYear := time.Date(2021, 01, 01, 0, 0, 0, 0, time.UTC)
+	startOfYear := time.Date(2021, 0o1, 0o1, 0, 0, 0, 0, time.UTC)
 	result := time.Now().Sub(startOfYear)
 	fmt.Println(result)
 }

--- a/tools/cmd/extract-changelog/main_test.go
+++ b/tools/cmd/extract-changelog/main_test.go
@@ -51,7 +51,7 @@ func TestMain(t *testing.T) {
 
 	changelog := filepath.Join(t.TempDir(), "CHANGELOG.md")
 	require.NoError(t,
-		os.WriteFile(changelog, []byte(_changelog), 0644))
+		os.WriteFile(changelog, []byte(_changelog), 0o644))
 
 	tests := []struct {
 		desc string


### PR DESCRIPTION
Run gofumpt over all files.
gofumpt is a stricter and more opinionated code formatter.
