### PR TITLE
diff: Use relative paths if input was relative

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ package main
 import (
 	"bytes"
 	"go/token"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,6 +149,7 @@ func TestPreview(t *testing.T) {
 			cmd := &mainCmd{
 				Stdout: &stdout,
 				Stderr: &stderr,
+				Getwd:  os.Getwd,
 			}
 
 			comment := []string{"example comment"}
@@ -164,6 +166,7 @@ func TestPreview(t *testing.T) {
 		cmd := &mainCmd{
 			Stdout: &stdout,
 			Stderr: &stderr,
+			Getwd:  os.Getwd,
 		}
 
 		comment := []string{"example comment"}

--- a/testdata/add_ctx_param
+++ b/testdata/add_ctx_param
@@ -34,6 +34,8 @@ func Send(context.Context, string) (*Response, error) {
 }
 
 -- send.diff --
+--- send.go
++++ send.go
 @@ -1,7 +1,7 @@
  package sender
  

--- a/testdata/add_iface_return
+++ b/testdata/add_iface_return
@@ -48,6 +48,8 @@ func (*bar) Do() error {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,12 +1,13 @@
  package a
  

--- a/testdata/const_to_var
+++ b/testdata/const_to_var
@@ -23,6 +23,8 @@ var (
 )
 
 -- top_level.diff --
+--- top_level.go
++++ top_level.go
 @@ -1,5 +1,5 @@
  package foo
  
@@ -50,6 +52,8 @@ func bar() {
 }
 
 -- nested.diff --
+--- nested.go
++++ nested.go
 @@ -1,7 +1,7 @@
  package foo
  

--- a/testdata/dedupe_args
+++ b/testdata/dedupe_args
@@ -22,6 +22,8 @@ func bar() {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,5 +1,6 @@
  package foo
  
@@ -47,6 +49,8 @@ func baz() {
 }
 
 -- bar.diff --
+--- bar.go
++++ bar.go
 @@ -1,5 +1,6 @@
  package bar
  

--- a/testdata/defer_return
+++ b/testdata/defer_return
@@ -36,6 +36,8 @@ func X() {
 }
 
 -- mutex.diff --
+--- mutex.go
++++ mutex.go
 @@ -2,6 +2,7 @@
  
  func X() {

--- a/testdata/delete_any_import
+++ b/testdata/delete_any_import
@@ -23,6 +23,8 @@ func x() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,7 +1,5 @@
  package x
  
@@ -49,6 +51,8 @@ func x() {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -1,7 +1,5 @@
  package x
  

--- a/testdata/delete_dots
+++ b/testdata/delete_dots
@@ -50,6 +50,8 @@ func zzz() {
 }
 
 -- stuff.diff --
+--- stuff.go
++++ stuff.go
 @@ -1,12 +1,6 @@
  package stuff
  

--- a/testdata/delete_field
+++ b/testdata/delete_field
@@ -38,6 +38,8 @@ func bar() {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -5,7 +5,7 @@
  func bar() {
  	foogit.Initialize(foogit.Params{
@@ -75,6 +77,8 @@ func bar() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -5,7 +5,7 @@
  func bar() {
  	foo.Initialize(foo.Params{

--- a/testdata/delete_import_panic
+++ b/testdata/delete_import_panic
@@ -40,6 +40,8 @@ func Example() {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,8 +1,8 @@
  package main
  

--- a/testdata/delete_struct_field
+++ b/testdata/delete_struct_field
@@ -39,6 +39,8 @@ type Bar struct {
 }
 
 -- delete.diff --
+--- delete.go
++++ delete.go
 @@ -2,12 +2,10 @@
  
  type Foo struct {

--- a/testdata/delete_unnamed_import
+++ b/testdata/delete_unnamed_import
@@ -25,6 +25,8 @@ func x() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,7 +1,5 @@
  package x
  

--- a/testdata/destutter
+++ b/testdata/destutter
@@ -44,6 +44,8 @@ func (c *Client) Do(
 }
 
 -- http_client.diff --
+--- http_client.go
++++ http_client.go
 @@ -2,15 +2,15 @@
  
  import "net/http"
@@ -92,6 +94,8 @@ func doStuff(client *http.Client) err {
 }
 
 -- unqualified_import.diff --
+--- unqualified_import.go
++++ unqualified_import.go
 @@ -2,7 +2,7 @@
  
  import "example.com/http"
@@ -129,6 +133,8 @@ func buildClient(c *http.Client) *myhttp.Client {
 }
 
 -- qualified_import.diff --
+--- qualified_import.go
++++ qualified_import.go
 @@ -6,6 +6,6 @@
  	myhttp "example.com/http"
  )

--- a/testdata/dts_in_args
+++ b/testdata/dts_in_args
@@ -21,6 +21,8 @@ func name(foo string, thingOne string, thingTwo func(...string) string, bar int)
 }
 
 -- dts_in_args.diff --
+--- dts_in_args.go
++++ dts_in_args.go
 @@ -1,5 +1,5 @@
  package a
  

--- a/testdata/dts_in_receiver
+++ b/testdata/dts_in_receiver
@@ -21,6 +21,8 @@ func (r *Receiver) name(bar string) string {
 }
 
 -- has_receiver.diff --
+--- has_receiver.go
++++ has_receiver.go
 @@ -1,5 +1,5 @@
  package a
  

--- a/testdata/dts_in_results
+++ b/testdata/dts_in_results
@@ -22,6 +22,8 @@ func name(foo string, bar int) (string, error) {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,5 +1,5 @@
  package a
  
@@ -55,6 +57,8 @@ func name(foo string, bar int) (val string, err error) {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -1,5 +1,5 @@
  package a
  

--- a/testdata/embed_to_field
+++ b/testdata/embed_to_field
@@ -29,6 +29,8 @@ type User struct {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,7 +1,7 @@
  package a
  

--- a/testdata/embed_to_newtype
+++ b/testdata/embed_to_newtype
@@ -17,6 +17,8 @@ package foo
 type A B
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,3 +1,3 @@
  package foo
  

--- a/testdata/foo_call_to_bar
+++ b/testdata/foo_call_to_bar
@@ -20,6 +20,8 @@ func main() {
 }
 
 -- simple.diff --
+--- simple.go
++++ simple.go
 @@ -1,5 +1,5 @@
  package main
  

--- a/testdata/func_within_a_func
+++ b/testdata/func_within_a_func
@@ -35,6 +35,8 @@ func foo(close func(*log.Logger) error) string {
 }
 
 -- one_dots.diff --
+--- one_dots.go
++++ one_dots.go
 @@ -5,7 +5,7 @@
  	"os"
  )

--- a/testdata/generic_instantiation
+++ b/testdata/generic_instantiation
@@ -26,6 +26,8 @@ func baz() {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,7 +1,7 @@
  package a
  

--- a/testdata/generics_in_src
+++ b/testdata/generics_in_src
@@ -34,6 +34,8 @@ func baz() {
 
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -2,10 +2,10 @@
  
  import "fmt"

--- a/testdata/gomock
+++ b/testdata/gomock
@@ -33,6 +33,8 @@ func TestFoo(t *testing.T) {
 }
 
 -- foo_test.diff --
+--- foo_test.go
++++ foo_test.go
 @@ -8,7 +8,6 @@
  
  func TestFoo(t *testing.T) {
@@ -81,6 +83,8 @@ func TestBar(t *testing.T) {
 }
 
 -- bar_test.diff --
+--- bar_test.go
++++ bar_test.go
 @@ -9,7 +9,6 @@
  func TestBar(t *testing.T) {
  	ctrl := gomock.NewController(t)
@@ -127,6 +131,8 @@ func TestBaz(t *testing.T) {
 }
 
 -- named_import.diff --
+--- named_import.go
++++ named_import.go
 @@ -8,7 +8,6 @@
  
  func TestBaz(t *testing.T) {

--- a/testdata/httpclient_use_ctx
+++ b/testdata/httpclient_use_ctx
@@ -82,6 +82,8 @@ func getResponse(ctx context.Context, req *http.Request) (*http.Response, error)
 }
 
 -- two_returns.diff --
+--- two_returns.go
++++ two_returns.go
 @@ -1,8 +1,12 @@
  package main
  

--- a/testdata/if_to_for
+++ b/testdata/if_to_for
@@ -28,6 +28,8 @@ func x() {
 }
 
 -- x.diff --
+--- x.go
++++ x.go
 @@ -1,7 +1,7 @@
  package foo
  

--- a/testdata/import_grouping
+++ b/testdata/import_grouping
@@ -39,6 +39,8 @@ func Foo(context.Context) error {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -2,12 +2,12 @@
  
  import (

--- a/testdata/inline_err_assignments
+++ b/testdata/inline_err_assignments
@@ -34,6 +34,8 @@ func bar() (*Result, error) {
 
 
 -- multiple.diff --
+--- multiple.go
++++ multiple.go
 @@ -2,8 +2,7 @@
  
  func bar() (*Result, error) {
@@ -69,6 +71,8 @@ func bar() error {
 }
 
 -- single.diff --
+--- single.go
++++ single.go
 @@ -2,8 +2,7 @@
  
  func bar() error {

--- a/testdata/inline_errors
+++ b/testdata/inline_errors
@@ -53,6 +53,8 @@ func bar() (Result, error) {
 }
 
 -- match.diff --
+--- match.go
++++ match.go
 @@ -2,8 +2,7 @@
  
  func bar() (Result, error) {
@@ -119,6 +121,8 @@ func qux() {
 }
 
 -- else.diff --
+--- else.go
++++ else.go
 @@ -1,12 +1,10 @@
  package foo
  
@@ -163,6 +167,8 @@ func foo() error {
 }
 
 -- case.diff --
+--- case.go
++++ case.go
 @@ -3,8 +3,7 @@
  func foo() error {
  	switch bar() {
@@ -202,6 +208,8 @@ func foo(ctx context.Context) error {
 }
 
 -- select.diff --
+--- select.go
++++ select.go
 @@ -3,8 +3,7 @@
  func foo(ctx context.Context) error {
  	select {

--- a/testdata/match_named_import
+++ b/testdata/match_named_import
@@ -50,6 +50,8 @@ func stuff() {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -1,7 +1,7 @@
  package whatever
  

--- a/testdata/matches_test_files
+++ b/testdata/matches_test_files
@@ -21,6 +21,8 @@ func y() {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,5 +1,5 @@
  package x
  
@@ -48,6 +50,8 @@ func TestThing(t *testing.T) {
 }
 
 -- foo_test.diff --
+--- foo_test.go
++++ foo_test.go
 @@ -3,5 +3,5 @@
  import "testing"
  

--- a/testdata/name_and_rewrite_unnamed_import
+++ b/testdata/name_and_rewrite_unnamed_import
@@ -27,6 +27,8 @@ func stuff() {
 
 
 -- user.diff --
+--- user.go
++++ user.go
 @@ -1,6 +1,6 @@
  package user
  

--- a/testdata/name_unnamed_import
+++ b/testdata/name_unnamed_import
@@ -26,6 +26,8 @@ func stuff() {
 }
 
 -- user.diff --
+--- user.go
++++ user.go
 @@ -1,6 +1,6 @@
  package user
  

--- a/testdata/nil_safe_string
+++ b/testdata/nil_safe_string
@@ -38,6 +38,8 @@ func (b *Bar) String() string {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -5,5 +5,8 @@
  }
  

--- a/testdata/noop_import
+++ b/testdata/noop_import
@@ -50,6 +50,8 @@ func foo(s string) *bool {
 }
 
 -- remove_all.diff --
+--- remove_all.go
++++ remove_all.go
 @@ -1,13 +1,11 @@
  package main
  
@@ -110,6 +112,8 @@ func foo(s string) *bool {
 }
 
 -- remove_some.diff --
+--- remove_some.go
++++ remove_some.go
 @@ -2,16 +2,18 @@
  
  import (

--- a/testdata/optimize_string_appends
+++ b/testdata/optimize_string_appends
@@ -53,6 +53,8 @@ func run() string {
 }
 
 -- loop.diff --
+--- loop.go
++++ loop.go
 @@ -1,11 +1,15 @@
  package foo
  

--- a/testdata/recognize_all_imports
+++ b/testdata/recognize_all_imports
@@ -26,6 +26,8 @@ func foo() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,6 +1,6 @@
  package whatever
  
@@ -54,6 +56,8 @@ func foo() {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -1,6 +1,6 @@
  package whatever
  

--- a/testdata/redundant_fmt_errorf
+++ b/testdata/redundant_fmt_errorf
@@ -31,6 +31,8 @@ func Do() error {
 }
 
 -- replace.diff --
+--- replace.go
++++ replace.go
 @@ -1,7 +1,7 @@
  package foo
  
@@ -68,6 +70,8 @@ func Do() error {
 }
 
 -- leave_sprintf.diff --
+--- leave_sprintf.go
++++ leave_sprintf.go
 @@ -1,9 +1,12 @@
  package bar
  

--- a/testdata/redundant_fmt_sprintf
+++ b/testdata/redundant_fmt_sprintf
@@ -46,6 +46,8 @@ func main() {
 }
 
 -- error.diff --
+--- error.go
++++ error.go
 @@ -7,7 +7,7 @@
  
  func boo() error {

--- a/testdata/remove_context_field
+++ b/testdata/remove_context_field
@@ -22,6 +22,8 @@ type Request struct {
 }
 
 -- alone.diff --
+--- alone.go
++++ alone.go
 @@ -1,5 +1,4 @@
  package alone
  
@@ -48,6 +50,8 @@ type Request struct {
 }
 
 -- triple.diff --
+--- triple.go
++++ triple.go
 @@ -2,6 +2,6 @@
  
  type Request struct {

--- a/testdata/rename_named_import
+++ b/testdata/rename_named_import
@@ -29,6 +29,8 @@ func stuff() {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,8 +1,8 @@
  package a
  

--- a/testdata/rename_package
+++ b/testdata/rename_package
@@ -27,6 +27,8 @@ func main() {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,4 +1,4 @@
 -package foo
 +package bar

--- a/testdata/rename_unnamed_import
+++ b/testdata/rename_unnamed_import
@@ -27,6 +27,8 @@ func foo() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,6 +1,6 @@
  package main
  

--- a/testdata/replace_any_import_with_unnamed
+++ b/testdata/replace_any_import_with_unnamed
@@ -27,6 +27,8 @@ func main() {
 }
 
 -- unnamed.diff --
+--- unnamed.go
++++ unnamed.go
 @@ -1,7 +1,7 @@
  package main
  
@@ -57,6 +59,8 @@ func main() {
 }
 
 -- named.diff --
+--- named.go
++++ named.go
 @@ -1,7 +1,7 @@
  package main
  

--- a/testdata/replace_import_with_top_level_comment
+++ b/testdata/replace_import_with_top_level_comment
@@ -32,6 +32,8 @@ func main() {
 }
 
 -- comment.diff --
+--- comment.go
++++ comment.go
 @@ -2,9 +2,7 @@
  
  package main

--- a/testdata/replace_net_context
+++ b/testdata/replace_net_context
@@ -26,6 +26,8 @@ func x() {
 }
 
 -- top_level.diff --
+--- top_level.go
++++ top_level.go
 @@ -1,6 +1,6 @@
  package foo
  
@@ -61,6 +63,8 @@ func x() {
 }
 
 -- import_group.diff --
+--- import_group.go
++++ import_group.go
 @@ -1,9 +1,8 @@
  package foo
  

--- a/testdata/replace_with_time_since
+++ b/testdata/replace_with_time_since
@@ -40,6 +40,8 @@ func main() {
 }
 
 -- time.diff --
+--- time.go
++++ time.go
 @@ -7,6 +7,6 @@
  
  func main() {

--- a/testdata/return_err
+++ b/testdata/return_err
@@ -21,6 +21,8 @@ func bar() error {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,4 +1,5 @@
  package foo
  

--- a/testdata/rewrite_import_paths
+++ b/testdata/rewrite_import_paths
@@ -30,6 +30,8 @@ func x() {
 }
 
 -- has_same_named_import.diff --
+--- has_same_named_import.go
++++ has_same_named_import.go
 @@ -1,6 +1,6 @@
  package bar
  
@@ -60,6 +62,8 @@ func y() {
 }
 
 -- has_different_named_import.diff --
+--- has_different_named_import.go
++++ has_different_named_import.go
 @@ -1,6 +1,6 @@
  package baz
  
@@ -88,6 +92,8 @@ func z() {
 }
 
 -- no_named_import.diff --
+--- no_named_import.go
++++ no_named_import.go
 @@ -1,6 +1,6 @@
  package baz
  

--- a/testdata/s1012
+++ b/testdata/s1012
@@ -42,6 +42,8 @@ func main() {
 }
 
 -- example.diff --
+--- example.go
++++ example.go
 @@ -13,5 +13,5 @@
  		log.Fatal(err)
  	}

--- a/testdata/s1028
+++ b/testdata/s1028
@@ -25,6 +25,8 @@ func bar(i int) error {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,10 +1,7 @@
  package foo
  

--- a/testdata/s1038
+++ b/testdata/s1038
@@ -22,6 +22,8 @@ func foo() {
 }
 
 -- example.diff --
+--- example.go
++++ example.go
 @@ -3,5 +3,5 @@
  import "fmt"
  

--- a/testdata/slice_and_import
+++ b/testdata/slice_and_import
@@ -27,6 +27,8 @@ func items() []string {
 }
 
 -- foo.diff --
+--- foo.go
++++ foo.go
 @@ -1,5 +1,7 @@
  package foo
  

--- a/testdata/stmt_to_expr
+++ b/testdata/stmt_to_expr
@@ -19,6 +19,8 @@ func b() {
 }
 
 -- a.diff --
+--- a.go
++++ a.go
 @@ -1,5 +1,5 @@
  package a
  

--- a/testdata/string_builder_for_loop
+++ b/testdata/string_builder_for_loop
@@ -43,6 +43,8 @@ func foo() string {
 }
 
 -- for_loop_three_clauses.diff --
+--- for_loop_three_clauses.go
++++ for_loop_three_clauses.go
 @@ -1,9 +1,13 @@
  package foo
  
@@ -85,6 +87,8 @@ func bar() {
 }
 
 -- for_loop_one_clause.diff --
+--- for_loop_one_clause.go
++++ for_loop_one_clause.go
 @@ -1,8 +1,12 @@
  package bar
  
@@ -131,6 +135,8 @@ func baz() {
 }
 
 -- range_one_result.diff --
+--- range_one_result.go
++++ range_one_result.go
 @@ -1,10 +1,15 @@
  package baz
  
@@ -176,6 +182,8 @@ func qux() {
 }
 
 -- range_two_results.diff --
+--- range_two_results.go
++++ range_two_results.go
 @@ -1,8 +1,12 @@
  package qux
  
@@ -222,6 +230,8 @@ func quux() {
 }
 
 -- range_no_results.diff --
+--- range_no_results.go
++++ range_no_results.go
 @@ -1,10 +1,15 @@
  package quux
  
@@ -267,6 +277,8 @@ func quuz() {
 }
 
 -- range_assign.diff --
+--- range_assign.go
++++ range_assign.go
 @@ -1,8 +1,12 @@
  package quuz
  

--- a/testdata/string_repeat
+++ b/testdata/string_repeat
@@ -34,6 +34,8 @@ func do() {
 
 
 -- buffer.diff --
+--- buffer.go
++++ buffer.go
 @@ -1,8 +1,7 @@
  package foo
  

--- a/testdata/struct_decl_field_rename
+++ b/testdata/struct_decl_field_rename
@@ -27,6 +27,8 @@ type User struct {
 }
 
 -- middle.diff --
+--- middle.go
++++ middle.go
 @@ -1,7 +1,7 @@
  package foo
  

--- a/testdata/struct_field_pair
+++ b/testdata/struct_field_pair
@@ -25,6 +25,8 @@ type Config struct {
 }
 
 -- config.diff --
+--- config.go
++++ config.go
 @@ -1,6 +1,5 @@
  package main
  

--- a/testdata/struct_init_field_rename
+++ b/testdata/struct_init_field_rename
@@ -30,6 +30,8 @@ func thing() {
 }
 
 -- first.diff --
+--- first.go
++++ first.go
 @@ -2,7 +2,7 @@
  
  func thing() {
@@ -63,6 +65,8 @@ func thing() {
 }
 
 -- middle.diff --
+--- middle.go
++++ middle.go
 @@ -3,7 +3,7 @@
  func thing() {
  	do(User{

--- a/testdata/type_to_alias
+++ b/testdata/type_to_alias
@@ -18,6 +18,8 @@ package x
 type UUID = string
 
 -- top_level.diff --
+--- top_level.go
++++ top_level.go
 @@ -1,3 +1,3 @@
  package x
  

--- a/testdata/undo_expr_patch
+++ b/testdata/undo_expr_patch
@@ -45,3 +45,7 @@ package main
 func main() {
 	foo(1)
 }
+
+-- a.diff --
+--- a.go
++++ a.go

--- a/testdata/unnamed_import_to_named
+++ b/testdata/unnamed_import_to_named
@@ -28,6 +28,8 @@ func foo() {
 }
 
 -- match.diff --
+--- match.go
++++ match.go
 @@ -1,6 +1,6 @@
  package a
  

--- a/testdata/value_group
+++ b/testdata/value_group
@@ -24,6 +24,8 @@ var (
 )
 
 -- top_level.diff --
+--- top_level.go
++++ top_level.go
 @@ -1,6 +1,6 @@
  package a
  
@@ -56,6 +58,8 @@ func foo() {
 }
 
 -- func.diff --
+--- func.go
++++ func.go
 @@ -2,8 +2,8 @@
  
  func foo() {

--- a/testdata/writebytes_to_write
+++ b/testdata/writebytes_to_write
@@ -30,6 +30,8 @@ func do() {
 }
 
 -- buffer.diff --
+--- buffer.go
++++ buffer.go
 @@ -2,7 +2,5 @@
  
  func do() {


### PR DESCRIPTION
For the `--diff` flag, if the input file path was relative,
also use relative file paths in generated diffs.

Besides providing more readable output,
this makes the output of `--diff` more useful
because these are now effectively relocatable .patch files.

This change also allows us to drop the hack in e2e test
where we drop the first two lines of the `--diff` output
so that we have something deterministic to compare against.
