### PR TITLE
diff/print-only: Report file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ return fmt.Errorf("invalid port: %v", err)
   ```
   Output would be : 
   ```
-  This patch replaces instances of fmt.Sprintf()
-  with fmt.Errorf()
-  Patch files can be applied to mutiple files
+  gopatch/testdata/test_files/diff_example/error.go:Replace redundant fmt.Sprintf with fmt.Errorf
   --- gopatch/testdata/test_files/diff_example/error.go
   +++ gopatch/testdata/test_files/diff_example/error.go
   @@ -7,7 +7,7 @@
@@ -512,17 +510,19 @@ if err := foo(); err != nil {
 For more on elision, see [Patches in depth/Elision].
 
   [Patches in depth/Elision]: docs/PatchesInDepth.md#elision
+
 ## Comments
+
 Patches come with comments to give more context about what they do.
 
 Comments are prefixed by '#'
 
 For example:
+
 ```
-# This patch replaces instances of time.Now().Sub(x)
-# with time.Since(x) where x is an identifier variable
+# Replace time.Now().Sub(x) with time.Since(x)
 @@
-# Var x is in the metavariable section 
+# var x is in the metavariable section 
 var x identifier
 @@
 
@@ -530,20 +530,19 @@ var x identifier
 +time.Since(x)
 # We replace time.Now().Sub(x)
 # with time.Since(x)
-
 ```
+
 #### Description comments
-These are the comments which explain what the patch does. There is
-no requirement for the patches to contain them but they are encouraged
-to give more context to the user. 
-The Description comments must occur just before the metavariable 
-section.
 
-For example:
+Description comments are comments that appear directly above a patch's first
+`@@` line.
+gopatch will record these descriptions and display them to users with use of
+the `--diff` or `--print-only` flags.
+
+For example,
+
 ```
-# Description comments
-# This patch replaces instances of time.Now().Sub(x)
-# with time.Since(x) where x is an identifier variable
+# Replace time.Now().Sub(x) with time.Since(x)
 @@
 # Not a description comment
 var x identifier
@@ -553,27 +552,21 @@ var x identifier
 +time.Since(x)
 # Not a description comment
 # Not a description comment
+```
+
+Patch files with multiple patches can have a separate description for each
+patch.
 
 ```
-Patch files which have multiple patches can have mutiple description
-comments. For example
-```
-# 1st patch Description comment
-# This patch replaces instances of fmt.Sprintf()
-# with fmt.Errorf()
-# Patch files can be applied to mutiple files
+# Replace redundant fmt.Sprintf with fmt.Errorf
+@@
 @@
 
-@@
-
-# Not a description comment
 -import "errors"
 -errors.New(fmt.Sprintf(...))
 +fmt.Errorf(...)
 
-# Start of 2nd Patch Description comment
-# This patch replaces instances of time.Now().Sub(x)
-# with time.Since(x) where x is an identifier variable
+# Replace time.Now().Sub(x) with time.Since(x)
 @@
 var x identifier
 @@
@@ -583,36 +576,36 @@ var x identifier
 # Not a description comment
 ```
 
-#### Usage during diff mode
-When diff mode is turned on by the '-d' flag we also display the 
-description/title comments of only the applied patches to help 
-the user understand what the patches do.
+As these are messages that will be printed to users of the patch,
+we recommend the following best practices for description comments.
+
+- Keep them short and on a single-line
+- Use imperative mood ("replace X with Y", not "replaces X with Y")
+
+#### Usage with `--diff`
+
+When diff mode is turned on by the `-d`/`--diff` flag, gopatch will print
+description comments for patches that matched different files to stderr.
 
 ```shell
 $ gopatch -d -p ~/s1028.patch testdata/test_files/diff_example/error.go
-```
-```
-  This patch replaces instances of fmt.Sprintf()
-  with fmt.Errorf()
-  Patch files can be applied to mutiple files
-  --- gopatch/testdata/test_files/diff_example/error.go
-  +++ gopatch/testdata/test_files/diff_example/error.go
-  @@ -7,7 +7,7 @@
- 
-  func foo() error {
-          err := errors.New("test")
-  -       return errors.New(fmt.Sprintf("error: %v", err))
-  +       return fmt.Errorf("error: %v", err)
-  }
- 
-   func main() {
+error.go:Replace redundant fmt.Sprintf with fmt.Errorf
+--- error.go
++++ error.go
+@@ -7,7 +7,7 @@
 
+func foo() error {
+        err := errors.New("test")
+-       return errors.New(fmt.Sprintf("error: %v", err))
++       return fmt.Errorf("error: %v", err)
+}
+
+ func main() {
 ```
-  Note: Only the description comments get displayed during diff mode.
-  Non description comments are ignored. 
-  Moreover, only comments from patches that actually apply on the 
-  target file are shown.
-  
+
+Note that gopatch will print only the description comments in diff mode.
+Other comments will be ignored.
+
 # Examples
 
 This section lists various example patches you can try in your code.

--- a/examples/gomock-v1.5.0.patch
+++ b/examples/gomock-v1.5.0.patch
@@ -1,7 +1,8 @@
-# In gomock 1.50, the Controller.Finish method is called automatically when
-# the test finishes running. We no longer need to call mockCtrl.Finish
-# manually.
+# Delete redundant gomock.Controller.Finish()
 @@
+# In gomock 1.50, the Controller.Finish method is called automatically when the
+# test finishes running.
+# We no longer need to call mockCtrl.Finish manually.
 var ctrl, gomock identifier
 var t expression
 @@

--- a/internal/parse/section/section_test.go
+++ b/internal/parse/section/section_test.go
@@ -170,7 +170,7 @@ func TestSplit(t *testing.T) {
 		{
 			desc: "comments",
 			give: text.Unlines(
-				"# This patch adds an argument.",
+				"# Add an argument",
 				"@@",
 				"  # x will match any identifier.",
 				"var x identifier",
@@ -192,7 +192,7 @@ func TestSplit(t *testing.T) {
 						line(129, "+x(42)"),
 					},
 					Comments: []string{
-						"This patch adds an argument.",
+						"Add an argument",
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -332,7 +332,7 @@ func (cmd *mainCmd) Run(args []string) error {
 		case opts.Diff:
 			err = cmd.preview(sourcePath.Provided, content, bs, comments)
 		case opts.Print:
-			cmd.printComments(comments)
+			cmd.printComments(sourcePath.Original, comments)
 			_, err = cmd.Stdout.Write(bs)
 		default:
 			err = os.WriteFile(filename, bs, 0o644)
@@ -354,13 +354,13 @@ func (cmd *mainCmd) preview(
 	originalContent, modifiedContent []byte,
 	comments []string,
 ) error {
-	cmd.printComments(comments)
+	cmd.printComments(filename, comments)
 	return diff.Text(filename, filename, originalContent, modifiedContent, cmd.Stdout)
 }
 
-func (cmd *mainCmd) printComments(comments []string) {
+func (cmd *mainCmd) printComments(filename string, comments []string) {
 	for _, c := range comments {
-		fmt.Fprintln(cmd.Stderr, c)
+		fmt.Fprintf(cmd.Stderr, "%v:%v\n", filename, c)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -125,10 +125,9 @@ func TestPreview(t *testing.T) {
 		filename string
 	}{
 		{
-			name:     "preview",
-			before:   "single line",
-			after:    "different line",
-			filename: "testdata/test_files/lint_example/time.go",
+			name:   "preview",
+			before: "single line",
+			after:  "different line",
 			want: "--- testdata/test_files/lint_example/time.go\n" +
 				"+++ testdata/test_files/lint_example/time.go\n" +
 				"@@ -1,1 +0,0 @@\n" +
@@ -137,8 +136,7 @@ func TestPreview(t *testing.T) {
 				"+different line\n",
 		},
 		{
-			name:     "empty file",
-			filename: "testdata/test_files/lint_example/time.go",
+			name: "empty file",
 			want: "--- testdata/test_files/lint_example/time.go\n" +
 				"+++ testdata/test_files/lint_example/time.go\n",
 		},
@@ -153,10 +151,10 @@ func TestPreview(t *testing.T) {
 			}
 
 			comment := []string{"example comment"}
-			err := cmd.preview(tt.filename, []byte(tt.before), []byte(tt.after), comment)
+			err := cmd.preview("testdata/test_files/lint_example/time.go", []byte(tt.before), []byte(tt.after), comment)
 			require.NoError(t, err)
 
-			assert.Equal(t, "example comment\n", stderr.String())
+			assert.Equal(t, "testdata/test_files/lint_example/time.go:example comment\n", stderr.String())
 			assert.Equal(t, tt.want, stdout.String())
 		})
 	}
@@ -173,7 +171,7 @@ func TestPreview(t *testing.T) {
 		err := cmd.preview("testdata/test_files/lint_example/time.go", nil, nil, comment)
 		require.NoError(t, err)
 
-		assert.Equal(t, "example comment\n", stderr.String())
+		assert.Equal(t, "testdata/test_files/lint_example/time.go:example comment\n", stderr.String())
 		assert.Equal(t,
 			"--- testdata/test_files/lint_example/time.go\n"+
 				"+++ testdata/test_files/lint_example/time.go\n",

--- a/testdata/add_ctx_param
+++ b/testdata/add_ctx_param
@@ -4,7 +4,7 @@ TODO: Collateral changes to callers of this function.
 TODO: Handle named and unnamed parameters automatically.
 
 -- add_ctx_param.patch --
-# This patch adds the context parameter to the function definition
+# Add context parameter to the function
 @@
 var f identifier
 @@
@@ -47,4 +47,4 @@ func Send(context.Context, string) (*Response, error) {
  	return &Response{}, nil
 
 -- send.diff.stderr --
-This patch adds the context parameter to the function definition
+send.go:Add context parameter to the function

--- a/testdata/delete_import_panic
+++ b/testdata/delete_import_panic
@@ -1,7 +1,7 @@
 Based on a user example of a panic.
 
 -- in.patch --
-# This patch replaces import fooclient.SetParams with compat.SetParams
+# Replace fooclient.SetParams with compat.SetParams
 @@
 @@
 -import fooclient "example.com/foo/client"
@@ -10,7 +10,7 @@ Based on a user example of a panic.
 -fooclient.SetParams
 +compat.SetParams
 
-# This patch replaces import fooclient.getClient with compat.GetClient
+# Replace fooclient.getClient with compat.GetClient
 @@
 @@
 -import fooclient "example.com/foo/client"
@@ -56,4 +56,4 @@ func Example() {
  }
 
 -- a.diff.stderr --
-This patch replaces import fooclient.getClient with compat.GetClient
+a.go:Replace fooclient.getClient with compat.GetClient

--- a/testdata/delete_unnamed_import
+++ b/testdata/delete_unnamed_import
@@ -1,7 +1,7 @@
 Delete an unnamed import verbatim.
 
 -- in.patch --
-# this patch removes an unnamed import verbatim.
+# Delete unnamed import
 @@
 @@
 -import "foo"
@@ -37,7 +37,7 @@ func x() {
  }
 
 -- unnamed.diff.stderr --
-this patch removes an unnamed import verbatim.
+unnamed.go:Delete unnamed import
 
 -- named.in.go --
 package x

--- a/testdata/embed_to_newtype
+++ b/testdata/embed_to_newtype
@@ -1,5 +1,5 @@
 -- in.patch --
-# This patch embeds to newtype
+# Convert embed to newtype
 @@
 var X, Y identifier
 @@
@@ -26,4 +26,4 @@ type A B
 +type A B
 
 -- foo.diff.stderr --
-This patch embeds to newtype
+foo.go:Convert embed to newtype

--- a/testdata/gomock
+++ b/testdata/gomock
@@ -45,9 +45,7 @@ func TestFoo(t *testing.T) {
  }
 
 -- foo_test.diff.stderr --
-In gomock 1.50, the Controller.Finish method is called automatically when
-the test finishes running. We no longer need to call mockCtrl.Finish
-manually.
+foo_test.go:Delete redundant gomock.Controller.Finish()
 
 -- bar_test.in.go --
 package bar
@@ -95,9 +93,7 @@ func TestBar(t *testing.T) {
  }
 
 -- bar_test.diff.stderr --
-In gomock 1.50, the Controller.Finish method is called automatically when
-the test finishes running. We no longer need to call mockCtrl.Finish
-manually.
+bar_test.go:Delete redundant gomock.Controller.Finish()
 
 -- named_import.in.go --
 package baz
@@ -143,6 +139,4 @@ func TestBaz(t *testing.T) {
  }
 
 -- named_import.diff.stderr --
-In gomock 1.50, the Controller.Finish method is called automatically when
-the test finishes running. We no longer need to call mockCtrl.Finish
-manually.
+named_import.go:Delete redundant gomock.Controller.Finish()

--- a/testdata/patch/error.patch
+++ b/testdata/patch/error.patch
@@ -1,6 +1,4 @@
-# This patch replaces instances of fmt.Sprintf()
-# with fmt.Errorf()
-# Patch files can be applied to mutiple files
+# Replace unnecessary fmt.Sprintf with fmt.Errorf
 @@
 # comments 5 -
 # comments 6 -

--- a/testdata/patch/time.patch
+++ b/testdata/patch/time.patch
@@ -1,5 +1,4 @@
-# This patch replaces instances of time.Now().Sub(x)
-# with time.Since(x) where x is an identifier variable
+# Replace time.Now().Sub() with time.Since()
 @@
 # comments 11 -
 # comments 12 -

--- a/testdata/redundant_fmt_sprintf
+++ b/testdata/redundant_fmt_sprintf
@@ -1,7 +1,5 @@
 -- redundant_fmt_sprintf.patch --
-# This patch replaces instances of fmt.Sprintf()
-# with fmt.Errorf()
-# Patch files can be applied to mutiple files
+# Replace errors.New(fmt.Sprintf()) with fmt.Errorf()
 @@
 # comments 5 -
 # comments 6 -
@@ -59,6 +57,4 @@ func main() {
  func main() {
 
 -- error.diff.stderr --
-This patch replaces instances of fmt.Sprintf()
-with fmt.Errorf()
-Patch files can be applied to mutiple files
+error.go:Replace errors.New(fmt.Sprintf()) with fmt.Errorf()

--- a/testdata/replace_with_time_since
+++ b/testdata/replace_with_time_since
@@ -1,6 +1,5 @@
 -- replace_with_time_since.patch --
-# This patch replaces time.Now.Sub()
-# with time.Since()
+# Replace time.Now().Sub() with time.Since()
 @@
 # comments 11 -
 # comments 12 -
@@ -52,5 +51,4 @@ func main() {
  }
 
 -- time.diff.stderr --
-This patch replaces time.Now.Sub()
-with time.Since()
+time.go:Replace time.Now().Sub() with time.Since()


### PR DESCRIPTION
Include names of matched files as we print comments to stderr.
This turns an unidentifiable stream of messages like,

    Replace foo with bar
    Replace foo with bar
    Replace baz with qux

Into more standard linter-style messages.

    foo.go:Replace foo with bar
    bar.go:Replace foo with bar
    foo.go:Replace baz with qux

In doing this, I went over the different sample patches we have in the
repository and came up with some best practices around this.
Seeing as these messages are meant to be shown to the user,
these should aim to be short and to the point.
So I suggest,

- Keep them on a single line
- Don't use "this patch" in the message
- Use imperative mood ("replace X with Y")

Basically, provide just enough information for a user to know what
happened.
