### PR TITLE
Add -P / --patches-file flag

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/token"
+	"io"
+	"os"
+
+	"github.com/uber-go/gopatch/internal/engine"
+	"github.com/uber-go/gopatch/internal/parse"
+	"go.uber.org/multierr"
+)
+
+// patchLoader loads patches from varying sources
+// and compiles them into a series of programs.
+type patchLoader struct {
+	fset  *token.FileSet
+	progs []*engine.Program
+
+	// Pointer to parseAndCompile function,
+	// which we can use to swap out this logic.
+	parseAndCompile func(*token.FileSet, string, []byte) (*engine.Program, error)
+}
+
+func newPatchLoader(fset *token.FileSet) *patchLoader {
+	return &patchLoader{
+		fset:            fset,
+		parseAndCompile: parseAndCompile,
+	}
+}
+
+func (l *patchLoader) Programs() []*engine.Program {
+	return l.progs
+}
+
+// LoadReader loads a patch from an io.Reader.
+func (l *patchLoader) LoadReader(name string, r io.Reader) error {
+	src, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+
+	prog, err := l.parseAndCompile(l.fset, name, src)
+	if err != nil {
+		return err
+	}
+
+	l.progs = append(l.progs, prog)
+	return nil
+}
+
+// LoadFile loads a patch from the given file.
+func (l *patchLoader) LoadFile(path string) (err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer multierr.AppendInvoke(&err, multierr.Close(f))
+
+	if err := l.LoadReader(path, f); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LoadFileList loads patches specified in a file
+// that contains a list of file paths to other patches.
+func (l *patchLoader) LoadFileList(patchList string) (err error) {
+	f, err := os.Open(patchList)
+	if err != nil {
+		return err
+	}
+	defer multierr.AppendInvoke(&err, multierr.Close(f))
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		path := scanner.Text()
+		if len(path) == 0 {
+			continue
+		}
+
+		if err := l.LoadFile(path); err != nil {
+			return fmt.Errorf("load patch %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// parseAndCompile parses the given patch contents,
+// and compiles them into a gopatch program.
+func parseAndCompile(fset *token.FileSet, name string, src []byte) (*engine.Program, error) {
+	astProg, err := parse.Parse(fset, name, src)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	prog, err := engine.Compile(fset, astProg)
+	if err != nil {
+		return nil, fmt.Errorf("compile: %w", err)
+	}
+	return prog, nil
+}

--- a/loader_test.go
+++ b/loader_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"errors"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/gopatch/internal/engine"
+)
+
+// fakeParseAndCompile builds a mock implementation of a function
+// matching the signature of parseAndCompile.
+//
+//	newFakeParseAndCompile(t).
+//		Expect(...).
+//		Return(...).
+//		Build()
+type fakeParseAndCompile struct {
+	t     *testing.T
+	calls []*loadCall // list of calls expected in-order
+}
+
+// newFakeParseAndCompile builds a new fakeParseAndCompile mock.
+func newFakeParseAndCompile(t *testing.T) *fakeParseAndCompile {
+	return &fakeParseAndCompile{t: t}
+}
+
+// Expect specifies that the mock should expect a calls
+// with the given file name and body.
+//
+// Expect returns a reference to the call object to allow specifying
+// the behavior for that expected call.
+func (m *fakeParseAndCompile) Expect(name string, body string) *loadCall {
+	call := &loadCall{parent: m, name: name, body: body}
+	m.calls = append(m.calls, call)
+	return call
+}
+
+// Build builds the mock expectations into a function
+// that can be set on patchLoader.
+func (m *fakeParseAndCompile) Build() func(fs *token.FileSet, name string, body []byte) (*engine.Program, error) {
+	t := m.t
+	return func(fs *token.FileSet, name string, body []byte) (*engine.Program, error) {
+		require.NotEmpty(t, m.calls, "unexpected call parseAndCompile(%v, %q, %q)", name, body)
+		call := m.calls[0]
+		m.calls = m.calls[1:]
+
+		assert.Equal(t, call.name, name, "unexpected file name")
+		assert.Equal(t, call.body, string(body), "unexpected file body")
+		return new(engine.Program), call.err
+	}
+}
+
+// loadCall is a single call expected by the mock.
+type loadCall struct {
+	parent *fakeParseAndCompile
+	name   string
+	body   string
+	err    error
+}
+
+// Return specifies that the mock call should return the given error.
+//
+// Return yields a reference to the mock itself to aid in chaining calls.
+func (c *loadCall) Return(err error) *fakeParseAndCompile {
+	c.err = err
+	return c.parent
+}
+
+func TestPatchLoader_LoadReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect("stdin", "hello").
+			Return(nil).
+			Build()
+
+		err := loader.LoadReader("stdin", strings.NewReader("hello"))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, loader.Programs())
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		t.Parallel()
+
+		giveErr := errors.New("great sadness")
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).Build()
+
+		err := loader.LoadReader("stdin", iotest.ErrReader(giveErr))
+		assert.ErrorContains(t, err, "read:")
+		assert.ErrorIs(t, err, giveErr)
+	})
+
+	t.Run("load error", func(t *testing.T) {
+		t.Parallel()
+
+		giveErr := errors.New("great sadness")
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect("stdin", "world").
+			Return(giveErr).
+			Build()
+
+		err := loader.LoadReader("stdin", strings.NewReader("world"))
+		assert.ErrorIs(t, err, giveErr)
+	})
+}
+
+func TestPatchLoader_LoadFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		file := writeFile(t, filepath.Join(t.TempDir(), "foo.patch"), "fix everything")
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect(file, "fix everything\n").
+			Return(nil).
+			Build()
+
+		require.NoError(t, loader.LoadFile(file))
+		assert.NotEmpty(t, loader.Programs())
+	})
+
+	t.Run("open error", func(t *testing.T) {
+		t.Parallel()
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).Build()
+
+		err := loader.LoadFile("some/file/that/does/not/exist.patch")
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("load error", func(t *testing.T) {
+		t.Parallel()
+
+		file := writeFile(t, filepath.Join(t.TempDir(), "foo.patch"), "fix everything")
+
+		giveErr := errors.New("great sadness")
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect(file, "fix everything\n").
+			Return(giveErr).
+			Build()
+
+		err := loader.LoadFile(file)
+		assert.ErrorIs(t, err, giveErr)
+	})
+}
+
+func TestPatchLoader_LoadFileList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+
+		fooPatch := writeFile(t, filepath.Join(dir, "foo.patch"), "fix foo")
+		barPatch := writeFile(t, filepath.Join(dir, "bar.patch"), "fix bar")
+		bazPatch := writeFile(t, filepath.Join(dir, "baz.patch"), "fix baz")
+		patchList := writeFile(t, filepath.Join(dir, "files.txt"),
+			fooPatch,
+			"",
+			barPatch,
+			bazPatch,
+			"", // extraneous empty lines
+		)
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect(fooPatch, "fix foo\n").Return(nil).
+			Expect(barPatch, "fix bar\n").Return(nil).
+			Expect(bazPatch, "fix baz\n").Return(nil).
+			Build()
+
+		require.NoError(t, loader.LoadFileList(patchList))
+	})
+
+	t.Run("open error", func(t *testing.T) {
+		t.Parallel()
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).Build()
+
+		err := loader.LoadFileList("some/file/that/does/not/exist.patch")
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("load error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		goodFile := writeFile(t, filepath.Join(dir, "good.patch"), "hi")
+		badFile := writeFile(t, filepath.Join(dir, "bad.patch"), "bye")
+		patchList := writeFile(t, filepath.Join(dir, "files.txt"),
+			goodFile,
+			badFile,
+			filepath.Join(dir, "does_not_exist.patch"), // never called
+		)
+
+		giveErr := errors.New("great sadness")
+
+		loader := newPatchLoader(token.NewFileSet())
+		loader.parseAndCompile = newFakeParseAndCompile(t).
+			Expect(goodFile, "hi\n").Return(nil).
+			Expect(badFile, "bye\n").Return(giveErr).
+			Build()
+
+		err := loader.LoadFileList(patchList)
+		assert.ErrorIs(t, err, giveErr)
+		assert.ErrorContains(t, err, badFile)
+	})
+}
+
+// writeFile writes a file with the given lines and returns its path.
+func writeFile(t *testing.T, path string, lines ...string) string {
+	t.Helper()
+
+	contents := strings.Join(lines, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644), "writeFile(%q)", path)
+	return path
+}


### PR DESCRIPTION
This adds a new flag '-P' that accepts a path to a file.
This file is expected to contain paths to zero or more other files,
which are all interpreted as arguments to '-p'.

So the following,

    % cat > patches.txt < EOF
    foo.patch
    bar.patch
    baz.patch
    EOF

    % gopatch -P patches.txt ...

Is equivalent to,

    % gopatch -p foo.patch -p bar.patch -p baz.patch ...

Empty lines in the patches file are ignored.
Comments are not supported at this time.

This makes it easier to write scripts where the list of patch files
comes from another source.

Refs GO-1679
