### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ running the following command in your terminal and place it on your `$PATH`.
   [Releases page]: https://github.com/uber-go/gopatch/releases
 
 ```bash
-VERSION=0.1.0
+VERSION=0.1.1
 URL="https://github.com/uber-go/gopatch/releases/download/v$VERSION/gopatch_${VERSION}_$(uname -s)_$(uname -m).tar.gz"
 curl -L "$URL" | tar xzv gopatch
 ```


### PR DESCRIPTION
Readme is currently pointing to 0.1.0 which is not the most recent version of gopatch.

Updated the README. Next time, we should remember to update this string when we release a new version of gopatch.