### PR TITLE
dependabot: Auto-update tools and GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure dependabot to auto-update tools dependencies (used for linting and codegen) and GitHub Actions.

Updating tools regularly should prevent issues like the staticcheck failure in https://github.com/uber-go/gopatch/pull/100.