### PR TITLE
#110 disable group import ordering

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/uber-go/gopatch/internal/astdiff"
 	"github.com/uber-go/gopatch/internal/engine"
 	"go.uber.org/multierr"
-	"golang.org/x/tools/imports"
 )
 
 func main() {
@@ -302,17 +301,7 @@ func (cmd *mainCmd) Run(args []string) error {
 			continue
 		}
 
-		bs, err := imports.Process(filename, out.Bytes(), &imports.Options{
-			Comments:   true,
-			TabIndent:  true,
-			TabWidth:   8,
-			FormatOnly: true,
-		})
-		if err != nil {
-			log.Printf("%s: failed: %v", filename, err)
-			errors = append(errors, fmt.Errorf("reformat %q: %v", filename, err))
-			continue
-		}
+		bs := out.Bytes()
 
 		switch {
 		case opts.Diff:

--- a/testdata/noop_import
+++ b/testdata/noop_import
@@ -75,10 +75,13 @@ func foo(s string) *bool {
 package main
 
 import (
+	"fmt"
+
 	"conversion/to.git"
 )
 
 func foo(s string) *bool {
+	fmt.Println("Hello World")
 	if to.StrPtr(s) == nil {
 		return to.BoolPtr(false)
 	}
@@ -94,12 +97,14 @@ func foo(s string) *bool {
 package main
 
 import (
-	"conversion/to.git"
+	"fmt"
 
+	"conversion/to.git"
 	"go.uber.org/thriftrw/ptr"
 )
 
 func foo(s string) *bool {
+	fmt.Println("Hello World")
 	if ptr.String(s) == nil {
 		return ptr.Bool(false)
 	}
@@ -114,15 +119,15 @@ func foo(s string) *bool {
 -- remove_some.diff --
 --- remove_some.go
 +++ remove_some.go
-@@ -2,16 +2,18 @@
+@@ -4,17 +4,18 @@
+ 	"fmt"
  
- import (
  	"conversion/to.git"
-+
 +	"go.uber.org/thriftrw/ptr"
  )
  
  func foo(s string) *bool {
+ 	fmt.Println("Hello World")
 -	if to.StrPtr(s) == nil {
 -		return to.BoolPtr(false)
 +	if ptr.String(s) == nil {


### PR DESCRIPTION
This commit disables import formatting for imports that were not part of the patch changes. We remove the call to `imports.Process` which was formatting the imports after the patch was applied.
This was tested in the testcase `testdata/noop_import`

An example is demonstrated in the [ issue ](https://github.com/uber-go/gopatch/issues/110#issue-1682374874) , where originally after the patch is applied we would get an extra change of group ordering.  I.e. :
```
import (
	"fmt"

	"conversion/to.git"

	"go.uber.org/thriftrw/ptr"
)
```
Which has unwanted group ordering

But after this commit's changes it becomes
```
import (
	"fmt"

	"conversion/to.git"
        "go.uber.org/thriftrw/ptr"
)
```
This example is added as a testcase under `testdata/noop_import`
Internal Ref: GO-1955