### PR TITLE
Add a flag `--skip-import-processing` to skip import processing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -54,9 +54,19 @@ func TestNewArgParser(t *testing.T) {
 				desc: "diff",
 				give: []string{"--diff", "-p", "testdata/patch/error.patch", "testdata/test_files/lint_example/test2.go"},
 				want: options{
-					Patches: []string{"testdata/patch/error.patch"},
-					Args:    arguments{Patterns: []string{"testdata/test_files/lint_example/test2.go"}},
-					Diff:    true,
+					Patches:              []string{"testdata/patch/error.patch"},
+					Args:                 arguments{Patterns: []string{"testdata/test_files/lint_example/test2.go"}},
+					Diff:                 true,
+					SkipImportProcessing: false,
+				},
+			},
+			{
+				desc: "skip-import-processing",
+				give: []string{"--skip-import-processing", "-p", "testdata/patch/replace_to_with_ptr.patch", "testdata/test_files/skip_import_processing_example/test1.go"},
+				want: options{
+					Patches:              []string{"testdata/patch/replace_to_with_ptr.patch"},
+					Args:                 arguments{Patterns: []string{"testdata/test_files/skip_import_processing_example/test1.go"}},
+					SkipImportProcessing: true,
 				},
 			},
 		}
@@ -68,6 +78,7 @@ func TestNewArgParser(t *testing.T) {
 				assert.Equal(t, tt.want.Patches, opts.Patches)
 				assert.Equal(t, tt.want.Args, opts.Args)
 				assert.Equal(t, tt.want.Diff, opts.Diff)
+				assert.Equal(t, tt.want.SkipImportProcessing, opts.SkipImportProcessing)
 			})
 		}
 	})

--- a/testdata/noop_import
+++ b/testdata/noop_import
@@ -75,10 +75,13 @@ func foo(s string) *bool {
 package main
 
 import (
+	"fmt"
+
 	"conversion/to.git"
 )
 
 func foo(s string) *bool {
+	fmt.Println("Hello World")
 	if to.StrPtr(s) == nil {
 		return to.BoolPtr(false)
 	}
@@ -94,12 +97,15 @@ func foo(s string) *bool {
 package main
 
 import (
+	"fmt"
+
 	"conversion/to.git"
 
 	"go.uber.org/thriftrw/ptr"
 )
 
 func foo(s string) *bool {
+	fmt.Println("Hello World")
 	if ptr.String(s) == nil {
 		return ptr.Bool(false)
 	}
@@ -114,15 +120,16 @@ func foo(s string) *bool {
 -- remove_some.diff --
 --- remove_some.go
 +++ remove_some.go
-@@ -2,16 +2,18 @@
+@@ -4,17 +4,19 @@
+ 	"fmt"
  
- import (
  	"conversion/to.git"
 +
 +	"go.uber.org/thriftrw/ptr"
  )
  
  func foo(s string) *bool {
+ 	fmt.Println("Hello World")
 -	if to.StrPtr(s) == nil {
 -		return to.BoolPtr(false)
 +	if ptr.String(s) == nil {
@@ -137,3 +144,31 @@ func foo(s string) *bool {
 -	return to.BoolPtr(true)
 +	return ptr.Bool(true)
  }
+
+-- remove_some.groupimports --
+--- remove_some.go
++++ remove_some.go
+@@ -4,17 +4,18 @@
+ 	"fmt"
+ 
+ 	"conversion/to.git"
++	"go.uber.org/thriftrw/ptr"
+ )
+ 
+ func foo(s string) *bool {
+ 	fmt.Println("Hello World")
+-	if to.StrPtr(s) == nil {
+-		return to.BoolPtr(false)
++	if ptr.String(s) == nil {
++		return ptr.Bool(false)
+ 	}
+ 
+ 	if to.DecimalPtr(s) == nil {
+-		return to.BoolPtr(false)
++		return ptr.Bool(false)
+ 	}
+ 
+-	return to.BoolPtr(true)
++	return ptr.Bool(true)
+ }
+

--- a/testdata/patch/replace_to_with_ptr.patch
+++ b/testdata/patch/replace_to_with_ptr.patch
@@ -1,0 +1,21 @@
+@@
+var to identifier
+@@
+import(
+-	to "conversion/to.git"
++	"go.uber.org/thriftrw/ptr"
+)
+
+-	to.StrPtr(...)
++	ptr.String(...)
+
+@@
+var to identifier
+@@
+import(
+-	to "conversion/to.git"
++	"go.uber.org/thriftrw/ptr"
+)
+
+-	to.BoolPtr(...)
++	ptr.Bool(...)

--- a/testdata/test_files/skip_import_processing_example/test1.go
+++ b/testdata/test_files/skip_import_processing_example/test1.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"conversion/to.git"
+)
+
+func foo(s string) *bool {
+	fmt.Println("Hello World")
+	if to.StrPtr(s) == nil {
+		return to.BoolPtr(false)
+	}
+
+	if to.DecimalPtr(s) == nil {
+		return to.BoolPtr(false)
+	}
+
+	return to.BoolPtr(true)
+}


### PR DESCRIPTION
This PR adds a flag `--skip-import-processing` to disables import formatting 
for imports that were not part of the patch changes. (#110)
When the flag `--skip-import-processings` is set to true, we remove the call to 
`imports.Process` which was formatting the imports after the patch was applied.
The flag being false has no affect and follows original behavior.

This was tested in the testcase testdata/noop_import, where without the
flag we get default patching. When the flag is set to true, the e2e_test 
confirms the diff doesn't have group ordering applied.

An additional file suffix `.groupimports` is added which contains the
diff between input file and the output after applying
`--skip-import-processing` flag.

Example for this case, if we don't pass `--skip-import-processing`, originally, 
after the patch is applied we would get an extra change of group ordering. 
I.e. :
```
import (
	fmt

	conversion/to.git

	go.uber.org/thriftrw/ptr
)
```

Which has unwanted group ordering

But after this commit's changes if we pass the `--skip-import-processing`
flag, it becomes 
```
import (
	fmt

	conversion/to.git
        go.uber.org/thriftrw/ptr
)
```
Internal Ref: GO-1955
