### PR TITLE
Fix #82 Match 1 or more returned values, Stricter

### DIFF
--- a/testdata/patch/return_elision.patch
+++ b/testdata/patch/return_elision.patch
@@ -1,0 +1,8 @@
+# Elision on function return argument
+@@
+@@
+ func f() (...) {
+- fmt.Println("")
++ fmt.Println("hello")
+  ...
+ }

--- a/testdata/test_files/test_return_elision.go
+++ b/testdata/test_files/test_return_elision.go
@@ -1,0 +1,13 @@
+package test_files
+
+import "fmt"
+
+func f() string {
+	fmt.Println("")
+	return ""
+}
+
+func main() {
+	str := f()
+	fmt.Println(str)
+}


### PR DESCRIPTION
This is a more stricter check which skips and move to the next matcher without modifying data if
 the current target node is invalid Position (no parenthesis)
- current matcher is PosMatcher and next is SliceDotsMatcher i.e. (...
- current matcher is PosMatcher and previous matcher was SliceDotsMatcher i.e. ...)